### PR TITLE
Optimization candidate 1

### DIFF
--- a/src/components/editable-document.jsx
+++ b/src/components/editable-document.jsx
@@ -399,6 +399,9 @@ class EditableDocument extends React.Component {
           rootFieldIndex={this.state.expanded ? 0 : index} />
       ));
       index++;
+      if (index > FIELD_LIMIT) {
+        break;
+      }
     }
     return components;
   }


### PR DESCRIPTION
## Before
12780ms

See `Handle Reset` case of #5 

## After
805ms (93.7% local speedup, ~86% total speedup, 2.1 seconds remaining in `Process documents` to optimize)

![screen shot 2017-08-22 at 5 21 32 pm](https://user-images.githubusercontent.com/1217010/29553560-f5d85314-875e-11e7-8f9f-398349260aa8.png)

Not known: What other side-effects this has.