### PR TITLE
COMPASS-1718 - Create BreadcrumbComponent

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,8 @@ const Actions = require('./lib/actions');
 const InsertDocumentStore = require('./lib/stores/insert-document-store');
 const ResetDocumentListStore = require('./lib/stores/reset-document-list-store');
 const LoadMoreDocumentsStore = require('./lib/stores/load-more-documents-store');
+const BreadcrumbStore = require('./lib/stores/breadcrumb-store');
+
 const {
   StandardEditor,
   DateEditor,
@@ -80,6 +82,7 @@ const activate = (appRegistry) => {
   appRegistry.registerStore('CRUD.InsertDocumentStore', InsertDocumentStore);
   appRegistry.registerStore('CRUD.ResetDocumentListStore', ResetDocumentListStore);
   appRegistry.registerStore('CRUD.LoadMoreDocumentsStore', LoadMoreDocumentsStore);
+  appRegistry.registerStore('CRUD.BreadcrumbStore', BreadcrumbStore);
 };
 
 /**
@@ -102,6 +105,7 @@ const deactivate = (appRegistry) => {
   appRegistry.deregisterStore('CRUD.InsertDocumentStore');
   appRegistry.deregisterStore('CRUD.ResetDocumentListStore');
   appRegistry.deregisterStore('CRUD.LoadMoreDocumentsStore');
+  appRegistry.deregisterStore('CRUD.BreadcrumbStore');
 };
 
 module.exports.activate = activate;

--- a/src/components/breadcrumb.jsx
+++ b/src/components/breadcrumb.jsx
@@ -1,0 +1,29 @@
+const React = require('react');
+const PropTypes = require('prop-types');
+
+class BreadcrumbComponent extends React.Component {
+
+  constructor(props) {
+    super(props);
+  }
+
+  render() {
+    return (
+      <div className="document-list-breadcrumb">
+        <span> {this.props.ns.ns}</span>
+      </div>
+    );
+  }
+}
+
+BreadcrumbComponent.propTypes = {
+  ns: PropTypes.object
+};
+
+BreadcrumbComponent.defaultPropTypes = {
+  ns: ['', '']
+};
+
+BreadcrumbComponent.displayName = 'BreadcrumbComponent';
+
+module.exports = BreadcrumbComponent;

--- a/src/components/document-list-table-view.jsx
+++ b/src/components/document-list-table-view.jsx
@@ -1,10 +1,18 @@
 const React = require('react');
 const PropTypes = require('prop-types');
+const BreadcrumbComponent = require('./breadcrumb');
+const BreadcrumbStore = require('../stores/breadcrumb-store');
+const { StoreConnector } = require('hadron-react-components');
 
 /**
  * Represents the table view of the documents tab.
  */
 class DocumentListTableView extends React.Component {
+  constructor(props) {
+    super(props);
+    const appRegistry = global.hadronApp.appRegistry;
+    this.NamespaceStore = appRegistry.getStore('App.NamespaceStore');
+  }
 
   /**
    * Render the document table view.
@@ -12,7 +20,12 @@ class DocumentListTableView extends React.Component {
    * @returns {React.Component} The component.
    */
   render() {
-    return (<div></div>);
+    return (
+      <div>
+        <StoreConnector store={BreadcrumbStore}>
+          <BreadcrumbComponent/>
+        </StoreConnector>
+      </div>);
   }
 }
 

--- a/src/stores/breadcrumb-store.js
+++ b/src/stores/breadcrumb-store.js
@@ -1,0 +1,48 @@
+const Reflux = require('reflux');
+const StateMixin = require('reflux-state-mixin');
+
+const mongodbns = require('mongodb-ns');
+
+const BreadcrumbStore = Reflux.createStore( {
+  mixins: [StateMixin.store],
+  /**
+   * Plugin lifecycle method that is called when the namespace changes in Compass.
+   *
+   * @param {string} namespace - the new namespace
+   */
+  onCollectionChanged(namespace) {
+    const nsobj = mongodbns(namespace);
+    if (nsobj.collection === '' || nsobj.ns === this.state.ns.ns) {
+      return;
+    }
+    this.setState({
+      ns: nsobj
+    });
+  },
+
+  /**
+   * Plugin lifecycle method that is called when the namespace changes in Compass.
+   *
+   * @param {string} namespace - the new namespace.
+   */
+  onDatabaseChanged(namespace) {
+    const nsobj = mongodbns(namespace);
+    if (!this.state.ns || this.state.ns.ns === nsobj.ns) {
+      return;
+    }
+    if (nsobj.collection === '') {
+      nsobj.collection = this.state.ns.collection;
+    }
+    this.setState({
+      ns: nsobj
+    });
+  },
+
+  getInitialState() {
+    return {
+      ns: mongodbns('')
+    };
+  }
+});
+
+module.exports = BreadcrumbStore;


### PR DESCRIPTION
This PR includes both a "BreadcrumbComponent" and a "BreadcrumbStore" because I needed the lifecycle methods for onCollectionChanged and onDatabaseChanged to be called for the BreadcrumbComponent. It feels weird to have a store only for listening to another store, but I assume it'll get fleshed out as more functionality is added.