### PR TITLE
COMPASS-1825 - Render empty cell with 'No field'

### DIFF
--- a/src/components/table-view/cell-renderer.jsx
+++ b/src/components/table-view/cell-renderer.jsx
@@ -109,8 +109,6 @@ class CellRenderer extends React.Component {
    * @returns {String} The element style.
    */
   style(base = BEM_BASE) {
-    if (this.element === undefined) return;
-
     let style = base;
     if (this.element.isAdded()) {
       style = style.concat(` ${base}-${ADDED}`);
@@ -137,9 +135,7 @@ class CellRenderer extends React.Component {
   renderEmptyCell() {
     return (
       <div className="table-cell">
-        <div className={this.style()}>
           No field
-        </div>
       </div>
     );
   }


### PR DESCRIPTION
This renders empty cells with 'no field'.

Right now it's returning out of 3 places which were causing errors because mounting and `isAdded()`.

<img width="747" alt="screen shot 2017-08-31 at 2 48 20 pm" src="https://user-images.githubusercontent.com/1305617/29939996-c521f992-8e5b-11e7-91ba-55e843eeb383.png">
