### PR TITLE
COMPASS-1964 - setTimeout and ag-grid API calls

### DIFF
--- a/src/components/document-table-view.jsx
+++ b/src/components/document-table-view.jsx
@@ -158,15 +158,6 @@ class DocumentTableView extends React.Component {
     const rowId = node.data.hadronDocument.get('_id').value.toString() + '0';
     const dataNode = this.gridApi.getRowNode(rowId);
 
-    // setTimeout(function() {
-    //   /* This data gets reset twice if being called from handleUpdate */
-    //   dataNode.data.hasFooter = false;
-    //   dataNode.data.state = null;
-    //   this.gridApi.refreshCells({rowNodes: [dataNode], columns: ['$rowActions'], force: true});
-    //   this.gridApi.updateRowData({remove: [node.data]});
-    //   this.gridApi.clearFocusedCell();
-    // }.bind(this), 0);
-
     dataNode.data.hasFooter = false;
     dataNode.data.state = null;
     this.gridApi.refreshCells({rowNodes: [dataNode], columns: ['$rowActions'], force: true});
@@ -191,11 +182,6 @@ class DocumentTableView extends React.Component {
     /* Update the row numbers */
     this.updateRowNumbers(dataNode.data.rowNumber, false);
 
-    /* Update the grid */
-    // setTimeout(function() {
-    //   this.gridApi.updateRowData({remove: [dataNode.data]});
-    // }.bind(this), 0);
-
     /* Remove the footer */
     this.removeFooter(node);
 
@@ -206,8 +192,8 @@ class DocumentTableView extends React.Component {
 
     /* Update the toolbar */
     Actions.documentRemoved();
-    // we want this to come last, but without making it a callback to something
-    // the only way to garauntee it is setTimeout
+
+    /* Update the grid */
     this.gridApi.updateRowData({remove: [dataNode.data]});
   }
 


### PR DESCRIPTION
This PR is to dig into why sometimes we need a `setTimeout` for the ag-grid API calls. 

- I've updated all the calls to use the same format `this.gridApi` since that was what was used the most already. This makes searching for the calls easier, too. 
- We are using `setTimeout` in just 2 places (of 22) with the API, but I'm not sure if:
  - there is another way to structure the code so that we don't need any timeouts
  - we need more timeouts.
- I googled but didn't find anything specifically talking about needing it on API calls, so not much help there.