### PR TITLE
Preliminary support for nested arrays

### DIFF
--- a/electron/renderer/index.js
+++ b/electron/renderer/index.js
@@ -12,7 +12,7 @@ const Connection = require('mongodb-connection-model');
 const DocumentList = require('../../lib/components/document-list');
 
 const DB = 'compass-crud';
-const COLL = 'test4';
+const COLL = 'test';
 
 const CONNECTION = new Connection({
   hostname: '127.0.0.1',

--- a/src/components/breadcrumb.jsx
+++ b/src/components/breadcrumb.jsx
@@ -57,8 +57,13 @@ class BreadcrumbComponent extends React.Component {
           {this.state.collection}
         </div>
         {this.state.path.map((name, i) => {
+          let displayName = '';
+          if (typeof name === 'number' && i > 0) {
+            displayName = this.state.path[i - 1] + '.';
+          }
+          displayName = displayName.concat(name);
           const className = (i === this.state.path.length - 1) ? `${BEM_BASE}-tab ${BEM_BASE}-tab-active` : `${BEM_BASE}-tab`;
-          return <span key={i} onClick={() => this.onTabClicked(i)} className={className}>{name} {ICON_TYPE[this.state.types[i]]}</span>;
+          return <span key={i} onClick={() => this.onTabClicked(i)} className={className}>{displayName} {ICON_TYPE[this.state.types[i]]}</span>;
         })}
       </div>
     );

--- a/src/components/table-view/cell-renderer.jsx
+++ b/src/components/table-view/cell-renderer.jsx
@@ -67,7 +67,7 @@ class CellRenderer extends React.Component {
     super(props);
     props.api.selectAll();
 
-    this.isEmpty = props.value === undefined;
+    this.isEmpty = props.value === undefined || props.value === null;
     this.isDeleted = false;
     this.element = props.value;
 
@@ -157,9 +157,9 @@ class CellRenderer extends React.Component {
     }
 
     if (this.element.currentType === 'Object') {
-      element = `{${this.element.elements.size}}`;
+      element = `{} ${this.element.elements.size} fields`;
     } else if (this.element.currentType === 'Array') {
-      element = `[${this.element.elements.size}]`;
+      element = `[] ${this.element.elements.size} elements`;
     } else {
       const component = getComponent(this.element.currentType);
       element = React.createElement(

--- a/src/components/table-view/header-cell-renderer.jsx
+++ b/src/components/table-view/header-cell-renderer.jsx
@@ -27,7 +27,7 @@ class HeaderCellRenderer extends React.Component {
 }
 
 HeaderCellRenderer.propTypes = {
-  displayName: PropTypes.string,
+  displayName: PropTypes.any,
   bsonType: PropTypes.string,
   hide: PropTypes.bool
 };


### PR DESCRIPTION
- Use only one instance of AG-Grid, and reset columns and headers when drilling down/up.
- Display entire array path, so “fieldname.0” instead of “0”.
- Keep column order when drilling down/up.
- Display “# elements” for arrays and “# fields” for objects, instead of [#] and {#}
- Support multi-document expand.