### PR TITLE
CLOUDP-26639: Carry timezones through to hadron-react-bson for ReadOnlyDocument

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,13 +83,13 @@
   "dependencies": {
     "ag-grid": "12.0.0",
     "ag-grid-react": "12.0.0",
+    "classnames": "^2.2.5",
     "hadron-document": "^4.0.0",
-    "hadron-react-bson": "^1.4.0",
+    "hadron-react-bson": "^1.12.0",
     "hadron-type-checker": "^4.0.2",
     "jquery": "^2.1.4",
     "lodash": "^4.17.4",
     "react-click-outside": "^2.2.0",
-    "react-tooltip": "^3.2.6",
-    "classnames": "^2.2.5"
+    "react-tooltip": "^3.2.6"
   }
 }

--- a/src/components/element.jsx
+++ b/src/components/element.jsx
@@ -101,6 +101,7 @@ class Element extends React.Component {
           key={element.uuid}
           element={element}
           expandAll={this.props.expandAll}
+          tz={this.props.tz}
         />)
       );
     }
@@ -156,7 +157,11 @@ class Element extends React.Component {
     const component = getComponent(this.props.element.currentType);
     return React.createElement(
       component,
-      { type: this.props.element.currentType, value: this.props.element.currentValue }
+      {
+        type: this.props.element.currentType,
+        value: this.props.element.currentValue,
+        tz: this.props.tz
+      }
     );
   }
 
@@ -174,7 +179,8 @@ Element.displayName = 'Element';
 
 Element.propTypes = {
   element: PropTypes.any.isRequired,
-  expandAll: PropTypes.bool
+  expandAll: PropTypes.bool,
+  tz: PropTypes.string
 };
 
 module.exports = Element;

--- a/src/components/readonly-document.jsx
+++ b/src/components/readonly-document.jsx
@@ -65,6 +65,7 @@ class ReadonlyDocument extends React.Component {
           key={element.uuid}
           element={element}
           expandAll={this.props.expandAll}
+          tz={this.props.tz}
         />
       ));
       index++;
@@ -115,7 +116,8 @@ ReadonlyDocument.displayName = 'ReadonlyDocument';
 
 ReadonlyDocument.propTypes = {
   doc: PropTypes.object.isRequired,
-  expandAll: PropTypes.bool
+  expandAll: PropTypes.bool,
+  tz: PropTypes.string
 };
 
 module.exports = ReadonlyDocument;


### PR DESCRIPTION
This just carries the timezone changes from hadron-react-bson through so that they can be used in Data Explorer. I've upgraded hadron-react-bson to the version published last night as part of this.

If you wouldn't mind doing a version bump after this is merged that would be awesome. Thanks!