### PR TITLE
CLOUDP-26639: Update Readonly Document when new props received

### DIFF
--- a/src/components/readonly-document.jsx
+++ b/src/components/readonly-document.jsx
@@ -47,6 +47,12 @@ class ReadonlyDocument extends React.Component {
     };
   }
 
+  componentWillReceiveProps(nextProps) {
+    if (this.props.doc !== nextProps.doc) {
+      this.doc = new HadronDocument(nextProps.doc);
+    }
+  }
+
   setRenderSize(newLimit) {
     this.setState({ renderSize: newLimit });
   }


### PR DESCRIPTION
Sorry for all the smaller PRs. I keep thinking I'm done with changes and that the hitches I'm hitting are on our end but this one came back to a change in compass-crud. During testing I realized that because `this.doc` ends up cached, when we changed the props one the component, `this.doc` never got re-initialized so we ended up with stale data being displayed. This fixes it so we update `this.doc` when `props.doc` changes.

(Side note, I wanted to get this on your radar ASAP but we're closed in the US today, Monday Jan 15 so no pressure to get to it today)