### PR TITLE
CLOUDP-26643: Bind cancel remove handler for Editable Document

### DIFF
--- a/src/components/editable-document.jsx
+++ b/src/components/editable-document.jsx
@@ -302,7 +302,7 @@ class EditableDocument extends React.Component {
         <RemoveDocumentFooter
           doc={this.props.doc}
           removeDocument={this.props.removeDocument}
-          cancelHandler={this.handleCancelRemove} />
+          cancelHandler={this.handleCancelRemove.bind(this)} />
       );
     }
   }


### PR DESCRIPTION
This binds the cancel remove handler for editable document so that you can close the notice that a file is flagged for deletion.

![compass](https://user-images.githubusercontent.com/1130737/36052227-c1fd7d02-0dba-11e8-9e50-9a57835c51f8.gif)


While you're here, if possible please grant me push access to compass-crud so that I don't have to go through a secretly forked repo managed by JB.

If you're good with these changes, please publish a new minor version so that we can use it on Cloud.

Thank you!