### PR TITLE
Remove Document from Document List

### DIFF
--- a/src/components/document-list.jsx
+++ b/src/components/document-list.jsx
@@ -132,6 +132,4 @@ DocumentList.defaultProps = {
   insert: {}
 };
 
-DocumentList.Document = Document;
-
 export default DocumentList;


### PR DESCRIPTION
This is a tiny commit—there's no usage of `DocumentList.Document` anywhere in the module, and we already export `Document`, so there should be no need for this. It's causing our tests for files that use compass-crud to fail, so I've removed it.