### PR TITLE
CLOUDP-26641: Manually track dropdown state instead of leaving to bootstrap

### DIFF
--- a/src/components/types.jsx
+++ b/src/components/types.jsx
@@ -47,7 +47,7 @@ class Types extends React.Component {
     if (this.element.currentType !== this.element.type) {
       className = `${className} editable-element-types-is-edited`;
     }
-    return this.state.isOpen ? `${className}` : `${className} closed`;
+    return this.state.isOpen ? `${className} open` : `${className} closed`;
   }
 
   /**
@@ -97,8 +97,8 @@ class Types extends React.Component {
     return this.props.version >= HP_VERSION;
   }
 
-  removeOpenClass() {
-    this.setState({ isOpen: !this.state.isOpen });
+  toggleOpenClass(isOpen = !this.state.isOpen) {
+    this.setState({ isOpen });
   }
 
   /**
@@ -116,8 +116,9 @@ class Types extends React.Component {
           id="types-dropdown"
           data-toggle="dropdown"
           aria-haspopup="true"
-          aria-expanded="false"
-          onBlur={this.removeOpenClass.bind(this)}
+          aria-expanded={this.state.isOpen}
+          onClick={() => this.toggleOpenClass()}
+          onBlur={() => this.toggleOpenClass(false)}
           ref={this.props.buttonRef ? this.props.buttonRef : () => {}}>
           {this.element.currentType}
           <span className="caret"></span>

--- a/src/components/types.spec.js
+++ b/src/components/types.spec.js
@@ -33,6 +33,42 @@ describe('<Types />', () => {
         expect(types.children().length).to.equal(19);
       });
 
+      it('sets the dropdown to closed', () => {
+        expect(wrapper.hasClass('closed')).to.be.true;
+      });
+
+      context('when clicking the button', () => {
+        beforeEach(() => {
+          const button = wrapper.find('#types-dropdown');
+          button.simulate('click');
+        });
+
+        afterEach(() => {
+          const button = wrapper.find('#types-dropdown');
+          button.simulate('click');
+        });
+
+        it('sets the dropdown to open', () => {
+          expect(wrapper.hasClass('open')).to.be.true;
+        });
+
+        context('when clicking the button again', () => {
+          beforeEach(() => {
+            const button = wrapper.find('#types-dropdown');
+            button.simulate('click');
+          });
+
+          afterEach(() => {
+            const button = wrapper.find('#types-dropdown');
+            button.simulate('click');
+          });
+
+          it('sets the dropdown to closed', () => {
+            expect(wrapper.hasClass('closed')).to.be.true;
+          });
+        });
+      });
+
       context('when selecting a type', () => {
         context('when the new type requires no special handling', () => {
           before(() => {


### PR DESCRIPTION
This is a small change that manually applies the bootstrap class `open` when the user clicks the `Types` dropdown button. I tested it in the `npm start` electron environment and it seemed to continue to work as is. We need this change on the Cloud side because we don't have the same bootstrap dropdown JS.