### PR TITLE
CLOUDP-28207: Remove bootstrap js import from Types.jsx

### DIFF
--- a/src/components/types.jsx
+++ b/src/components/types.jsx
@@ -3,8 +3,6 @@ import PropTypes from 'prop-types';
 import TypeChecker from 'hadron-type-checker';
 import { DateEditor } from 'components/editor';
 
-import 'bootstrap/js/dropdown';
-
 /**
  * Object constant.
  */


### PR DESCRIPTION
This is a followup to the last PR where I added the state of the dropdown to the Types component. Here, I'm just removing the extra `bootstrap/js/dropdown` import because it's no longer necessary (and conflicts with Cloud's bootstrap, resulting in all dropdowns immediately showing and re-hiding themselves when clicked).