### PR TITLE
use utc time to display dates

### DIFF
--- a/src/components/document-list-view.jsx
+++ b/src/components/document-list-view.jsx
@@ -35,6 +35,7 @@ class DocumentListView extends React.Component {
         <li className={LIST_ITEM_CLASS} data-test-id={LIST_ITEM_TEST_ID} key={i}>
           <Document
             doc={doc}
+            tz="UTC"
             key={i}
             editable={this.props.isEditable}
             version={this.props.version}

--- a/src/components/document.jsx
+++ b/src/components/document.jsx
@@ -29,6 +29,7 @@ Document.displayName = 'Document';
 
 Document.propTypes = {
   doc: PropTypes.object.isRequired,
+  tz: PropTypes.string,
   editable: PropTypes.bool,
   expandAll: PropTypes.bool,
   removeDocument: PropTypes.func,

--- a/src/components/editable-document.jsx
+++ b/src/components/editable-document.jsx
@@ -244,6 +244,7 @@ class EditableDocument extends React.Component {
         <EditableElement
           key={element.uuid}
           element={element}
+          tz={this.props.tz}
           indent={0}
           version={this.props.version}
           editing={this.state.editing}
@@ -336,6 +337,7 @@ EditableDocument.propTypes = {
   updateDocument: PropTypes.func.isRequired,
   version: PropTypes.string.isRequired,
   editable: PropTypes.bool,
+  tz: PropTypes.string,
   expandAll: PropTypes.bool,
   openInsertDocumentDialog: PropTypes.func.isRequired,
   copyToClipboard: PropTypes.func.isRequired

--- a/src/components/editable-element.jsx
+++ b/src/components/editable-element.jsx
@@ -325,8 +325,7 @@ class EditableElement extends React.Component {
       <div
         className={`editable-element-expand-button ${HEADER_TOGGLE}`}
         style={this.inlineToggleStyle()}
-        onClick={this.toggleExpandable.bind(this)}>
-      </div>
+        onClick={this.toggleExpandable.bind(this)}/>
     );
   }
 
@@ -357,7 +356,7 @@ class EditableElement extends React.Component {
     const component = getComponent(this.element.currentType);
     const reactComponent = React.createElement(
       component,
-      { type: this.element.currentType, value: this.element.currentValue }
+      { type: this.element.currentType, value: this.element.currentValue, tz: this.props.tz }
     );
 
     return <span className={WRAPPER} onDoubleClick={this.focusEditValue.bind(this)}>{reactComponent}</span>;
@@ -420,6 +419,7 @@ EditableElement.displayName = 'EditableElement';
 EditableElement.propTypes = {
   editing: PropTypes.bool,
   edit: PropTypes.func,
+  tz: PropTypes.string,
   element: PropTypes.object.isRequired,
   version: PropTypes.string.isRequired,
   index: PropTypes.number,

--- a/src/components/element.jsx
+++ b/src/components/element.jsx
@@ -134,7 +134,7 @@ class Element extends React.Component {
     return (
       <li className={EXP_CLASS}>
         <div className={this.getClassName(EXP_HEADER)} onClick={this.toggleExpandable.bind(this)}>
-          <div className={EXP_TOGGLE}></div>
+          <div className={EXP_TOGGLE}/>
           <div className={EXP_FIELD}>{this.props.element.currentKey}</div>
           <span className={EXP_SEPARATOR}>:</span>
           <div className={EXP_LABEL}>

--- a/src/components/no-action.jsx
+++ b/src/components/no-action.jsx
@@ -17,7 +17,7 @@ class NoAction extends React.Component {
    */
   render() {
     return (
-      <div className={ACTIONS}></div>
+      <div className={ACTIONS}/>
     );
   }
 }

--- a/src/components/types.jsx
+++ b/src/components/types.jsx
@@ -119,7 +119,7 @@ class Types extends React.Component {
           onBlur={() => this.toggleOpenClass(false)}
           ref={this.props.buttonRef ? this.props.buttonRef : () => {}}>
           {this.element.currentType}
-          <span className="caret"></span>
+          <span className="caret"/>
         </button>
         <ul className="dropdown-menu" aria-labelledby="types-dropdown">
           {this.renderTypes()}


### PR DESCRIPTION
`hadron-react` date component uses `tz` to set appropriate time. To avoid changing how that particular component works ( i am assuming we are not the only ones that use it), this sets a prop in `<Document>` to allow for timezones. Timezone is set to UTC to reflect server time.

Questions:

1. Should it be UTC, *or* should it be the legit server time that the databases' servers are in? For me setting this to UTC matched to times that were in my shell, but I am not sure if this is universal.
1a. Is UTC the actual universal server time?
2. Not sure if setting `tz` as a prop on the `<Document>` is a good enough idea? It does make it easier for compass aggregations, since this is what we use to display documents there.

time is ~ h ~ a ~ r ~ d ~