### PR TITLE
readonly doc should take a tz prop

### DIFF
--- a/src/components/document.jsx
+++ b/src/components/document.jsx
@@ -20,6 +20,7 @@ class Document extends React.Component {
     return (
       <ReadonlyDocument
         doc={this.props.doc}
+        tz={this.props.tz}
         expandAll={this.props.expandAll} />
     );
   }


### PR DESCRIPTION
Compass-Aggregations uses Readonly Document to display its documents, so `tz` prop should also be passed to Readonly.