### PR TITLE
CLOUDP-34934: Data Explorer fails to work with Date fields through Safari

### DIFF
--- a/src/components/editor/date.js
+++ b/src/components/editor/date.js
@@ -7,7 +7,7 @@ import StandardEditor from './standard';
 /**
  * The date format.
  */
-const FORMAT = 'YYYY-MM-DD HH:mm:ss.SSSZ';
+const FORMAT = 'YYYY-MM-DDTHH:mm:ss.SSSZ';
 
 /**
  * CRUD editor for date values.

--- a/src/components/editor/date.spec.js
+++ b/src/components/editor/date.spec.js
@@ -5,7 +5,7 @@ import moment from 'moment-timezone';
 describe('DateEditor', () => {
   describe('#start', () => {
     const dateString = '2017-01-01 00:00:00.000';
-    const formattedDateString = '2017-01-01 00:00:00.000+00:00';
+    const formattedDateString = '2017-01-01T00:00:00.000+00:00';
     const tz = 'UTC';
     const date = moment.tz(dateString, tz);
     const element = new Element('date', date, false);
@@ -218,7 +218,7 @@ describe('DateEditor', () => {
     context('when the ui is not in edit mode', () => {
       context('when the date is valid', () => {
         const dateString = '2017-01-01 00:00:00.000';
-        const formattedDateString = '2017-01-01 00:00:00.000+00:00';
+        const formattedDateString = '2017-01-01T00:00:00.000+00:00';
         const tz = 'UTC';
         const date = moment.tz(dateString, tz);
         const element = new Element('date', date, false);


### PR DESCRIPTION
Fixing a bug in date explorer in Safari where all dates are marked as invalid after being formatted [CLOUDP-34934](https://jira.mongodb.org/browse/CLOUDP-34934)

Change to using ISO date format (as Safari's implementation of Date fails to parse milliseconds in all other formats)