### PR TITLE
store.refreshDocuments() needs to be bound

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3180,6 +3180,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -8195,7 +8196,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8216,12 +8218,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8236,17 +8240,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8363,7 +8370,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8375,6 +8383,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8389,6 +8398,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8396,12 +8406,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8420,6 +8432,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -8500,7 +8513,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -8512,6 +8526,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -8597,7 +8612,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -8633,6 +8649,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -8652,6 +8669,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8695,12 +8713,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -9448,7 +9468,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.5",
@@ -15040,7 +15061,7 @@
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.4.0",
         "mongodb-ns": "^2.0.0",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "triejs": "github:rueckstiess/triejs"
       },
       "dependencies": {
         "ampersand-class-extend": {
@@ -15600,7 +15621,7 @@
         "lodash.defaults": "^4.2.0",
         "lodash.uniq": "^4.5.0",
         "minimist": "^1.2.0",
-        "pre-commit": "github:mongodb-js/pre-commit#f4158768a7ef58b46808cc09a6f6a0994c0baa67",
+        "pre-commit": "github:mongodb-js/pre-commit",
         "precinct": "^6.1.0"
       },
       "dependencies": {
@@ -15987,7 +16008,7 @@
       "dev": true,
       "requires": {
         "bson": "^1.0.9",
-        "context-eval": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
+        "context-eval": "github:durran/context-eval",
         "debug": "^3.1.0",
         "is-json": "^2.0.1",
         "javascript-stringify": "^1.6.0",
@@ -16066,7 +16087,7 @@
         "mkdirp": "^0.5.1",
         "mongodb": "^2.2.8",
         "mongodb-dbpath": "^0.0.1",
-        "mongodb-tools": "github:mongodb-js/mongodb-tools#8da4724189dfdf7b0d02d87db14b7ce94adf6342",
+        "mongodb-tools": "github:mongodb-js/mongodb-tools",
         "mongodb-version-manager": "^1.1.1",
         "untildify": "^3.0.0",
         "which": "^1.2.4"

--- a/src/stores/crud-store.js
+++ b/src/stores/crud-store.js
@@ -652,7 +652,7 @@ const configureStore = (options = {}) => {
       options.dataProvider.dataProvider
     );
 
-    store.refreshDocuments();
+    store.refreshDocuments.bind(store);
   }
 
   const gridStore = configureGridStore(options);


### PR DESCRIPTION
## Context

A few of the tests were not passing due to a call to `refreshDocuments()` not having a `.bind()`. These test failures also indicate that documents were not being actually refreshed when they should be. This PR fixes that problem.
<img width="817" alt="Screen Shot 2019-07-31 at 14 40 18" src="https://user-images.githubusercontent.com/8107784/62212600-5c3b2f80-b3a1-11e9-8ca8-e080eb7704ee.png">
<img width="533" alt="Screen Shot 2019-07-31 at 14 40 26" src="https://user-images.githubusercontent.com/8107784/62212603-5e04f300-b3a1-11e9-8e8f-e2add59ef6dd.png">


## Semver
Patch