### PR TITLE
retain current document in state when cancelling mid edit

### DIFF
--- a/src/components/json-editor.jsx
+++ b/src/components/json-editor.jsx
@@ -125,7 +125,7 @@ class EditableJson extends React.Component {
       editing: false,
       mode: VIEWING,
       message: EMPTY,
-      value: this.props.doc
+      json: jsBeautify(EJSON.stringify(this.props.doc.generateObject()))
     });
 
     this.props.clearUpdateStatus();


### PR DESCRIPTION
## Description
Currently when editing a document in json and changing your mind half way through, hitting `Cancel` will keep your edits in `isEditable: false` state. This PR ensures that the original document is retained when cancelling. 

## Semver
- [x] Patch