### PR TITLE
[WIP] COMPASS-3806: add int64 crud editor support

### DIFF
--- a/src/components/editor/index.js
+++ b/src/components/editor/index.js
@@ -2,6 +2,7 @@ import StandardEditor from './standard';
 import StringEditor from './string';
 import Decimal128Editor from './decimal128';
 import Int32Editor from './int32';
+import Int64Editor from './int64';
 import DoubleEditor from './double';
 import DateEditor from './date';
 import NullEditor from './null';
@@ -16,6 +17,7 @@ const init = (element, tz) => {
     'Date': new DateEditor(element, tz),
     'Double': new DoubleEditor(element),
     'Int32': new Int32Editor(element),
+    'Int64': new Int64Editor(element),
     'Null': new NullEditor(element),
     'Undefined': new UndefinedEditor(element),
     'ObjectId': new ObjectIdEditor(element)

--- a/src/components/editor/int64.js
+++ b/src/components/editor/int64.js
@@ -1,0 +1,62 @@
+import TypeChecker from 'hadron-type-checker';
+import { Element } from 'hadron-document';
+import StandardEditor from './standard';
+import chars from 'utils';
+
+/**
+ * CRUD editor for int32 values.
+ */
+class Int64Editor extends StandardEditor {
+  /**
+   * Create the editor with the element.
+   *
+   * @param {Element} element - The hadron document element.
+   */
+  constructor(element) {
+    super(element);
+  }
+
+  /**
+   * Complete the int64 edit by converting the valid string to a int64
+   * value or leaving as invalid.
+   */
+  complete() {
+    if (this.element.isCurrentTypeValid()) {
+      this.element.edit(TypeChecker.cast(this.element.currentValue, 'Int64'));
+    }
+  }
+
+  /**
+   * Edit Int64 element. Check if the value is a Int64 before setting typed
+   * up value.
+   *
+   * @param {Object} value - The new value.
+   */
+  edit(value) {
+    try {
+      TypeChecker.cast(value, 'Int64');
+      this.element.currentValue = value;
+      this.element.setValid();
+      this.element._bubbleUp(Element.Events.Edited);
+    } catch (error) {
+      this.element.setInvalid(value, this.element.currentType, error.message);
+    }
+  }
+
+  /**
+   * Get the number of characters the value should display.
+   *
+   * @param {Boolean} editMode - If the element is being edited.
+   *
+   * @returns {Number} The number of characters.
+   */
+  size() {
+    return chars(this.element.currentValue);
+  }
+
+  value() {
+    return this.element.currentValue;
+  }
+}
+
+export default Int64Editor;


### PR DESCRIPTION
## Description
COMPASS-3806 encompasses (get it? :D) two issues: 1) Int64 value was not properly cast and set to be the `currentValue` when edited and 2) JavaScript does not allow for a value that large to be displayed. 

This PR fixes 1), but 2) is still an issue I was not able to yet solve.

### Checklist
- [ ] New tests and/or benchmarks are included

## Motivation and Context
- [x] Bugfix

## Open Questions
I've tried a few things to get the value to display properly on `value` editor state. It seems like `Long` BSON value is getting stored properly, it's just a matter of converting it back to some sort of number afterwards.

Using `currentValue.toNumber`, `currentValue.toString`, or `currentValue.valueOf` in int64's `value` event does not yield the expected result (where `currentValue` is a `Long` object). 

There is a [thread in slack](https://mongodb.slack.com/archives/GH3D2QP9U/p1567605302001600) about the whole situation.

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)
