### PR TITLE
COMPASS-3830: introduce zero-state for document view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3282,6 +3282,7 @@
       "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
       "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
       "dev": true,
+      "optional": true,
       "requires": {
         "hoek": "2.x.x"
       }
@@ -4314,11 +4315,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
       "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
-      "dev": true
-    },
-    "context-eval": {
-      "version": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
-      "from": "github:durran/context-eval",
       "dev": true
     },
     "convert-source-map": {
@@ -8768,7 +8764,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -8789,12 +8786,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -8809,17 +8808,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -8936,7 +8938,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -8948,6 +8951,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -8962,6 +8966,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -8969,12 +8974,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -8993,6 +9000,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -9073,7 +9081,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -9085,6 +9094,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -9170,7 +9180,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -9206,6 +9217,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -9225,6 +9237,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -9268,12 +9281,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -10049,7 +10064,8 @@
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
       "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "hoist-non-react-statics": {
       "version": "2.5.5",
@@ -15596,8 +15612,7 @@
         "lodash": "^4.8.2",
         "mongodb": "^3.1.9",
         "mongodb-js-errors": "^0.4.0",
-        "mongodb-ns": "^2.0.0",
-        "triejs": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
+        "mongodb-ns": "^2.0.0"
       },
       "dependencies": {
         "ampersand-class-extend": {
@@ -16030,6 +16045,10 @@
           "resolved": "https://registry.npmjs.org/qs/-/qs-4.0.0.tgz",
           "integrity": "sha1-wx2bdOwn33XlQ6hseHKO2NRiNgc=",
           "dev": true
+        },
+        "triejs": {
+          "version": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5",
+          "from": "github:rueckstiess/triejs#dd30f999a9a98420e1de8e2b2ff2e6ab742ce4a5"
         }
       }
     },
@@ -16182,7 +16201,7 @@
         "lodash.defaults": "^4.2.0",
         "lodash.uniq": "^4.5.0",
         "minimist": "^1.2.0",
-        "pre-commit": "github:mongodb-js/pre-commit#f4158768a7ef58b46808cc09a6f6a0994c0baa67",
+        "pre-commit": "github:mongodb-js/pre-commit",
         "precinct": "^6.1.0"
       },
       "dependencies": {
@@ -16578,7 +16597,6 @@
       "dev": true,
       "requires": {
         "bson": "^1.0.9",
-        "context-eval": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
         "debug": "^3.1.0",
         "is-json": "^2.0.1",
         "javascript-stringify": "^1.6.0",
@@ -16590,6 +16608,10 @@
         "safer-eval": "^1.3.5"
       },
       "dependencies": {
+        "context-eval": {
+          "version": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d",
+          "from": "github:durran/context-eval#8900e57d1e9995f641ee601761672d1f9c5c726d"
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -16643,7 +16665,7 @@
         "mkdirp": "^0.5.1",
         "mongodb": "^2.2.8",
         "mongodb-dbpath": "^0.0.1",
-        "mongodb-tools": "github:mongodb-js/mongodb-tools#8da4724189dfdf7b0d02d87db14b7ce94adf6342",
+        "mongodb-tools": "github:mongodb-js/mongodb-tools",
         "mongodb-version-manager": "^1.1.1",
         "untildify": "^3.0.0",
         "which": "^1.2.4"

--- a/src/actions/index.js
+++ b/src/actions/index.js
@@ -19,6 +19,7 @@ const configureActions = () => {
     'toggleInsertDocumentView',
     'toggleInsertDocument',
     'openInsertDocumentDialog',
+    'openExportFileDialog',
     'openImportFileDialog',
     'pathChanged',
     'refreshDocuments',

--- a/src/components/document-list.jsx
+++ b/src/components/document-list.jsx
@@ -155,6 +155,7 @@ DocumentList.propTypes = {
   store: PropTypes.object.isRequired,
   openInsertDocumentDialog: PropTypes.func,
   openImportFileDialog: PropTypes.func,
+  openExportFileDialog: PropTypes.func,
   view: PropTypes.string.isRequired,
   updateError: PropTypes.string,
   updateJsonDoc: PropTypes.func,

--- a/src/components/document-list.jsx
+++ b/src/components/document-list.jsx
@@ -13,9 +13,9 @@ import Toolbar from 'components/toolbar';
 import './index.less';
 import './ag-grid-dist.css';
 
-const HEADER = "This collection has no data";
+const HEADER = 'This collection has no data';
 
-const SUBTEXT = "It only takes a few seconds to import data from a JSON or CSV file";
+const SUBTEXT = 'It only takes a few seconds to import data from a JSON or CSV file';
 
 /**
  * Component for the entire document list.
@@ -130,23 +130,23 @@ class DocumentList extends React.Component {
   renderZeroState() {
     const editableClass = !this.props.isEditable ? 'disabled' : '';
 
-		if (this.props.docs.length === 0) {
-			return (
-				<div className="document-list-zero-state">
-					<ZeroGraphic />
-					<ZeroState header={HEADER} subtext={SUBTEXT}>
-						<div className="document-list-zero-state-action">
-							<div>
-								<TextButton
-									className={`btn btn-primary btn-lg ${editableClass}`}
-									text="ImportData"
-									clickHandler={this.props.openImportFileDialog} />
-							</div>
-						</div>
-					</ZeroState>
-				</div>
-			);
-		}
+    if (this.props.docs.length === 0) {
+      return (
+        <div className="document-list-zero-state">
+          <ZeroGraphic />
+          <ZeroState header={HEADER} subtext={SUBTEXT}>
+            <div className="document-list-zero-state-action">
+              <div>
+                <TextButton
+                  className={`btn btn-primary btn-lg ${editableClass}`}
+                  text="ImportData"
+                  clickHandler={this.props.openImportFileDialog} />
+              </div>
+            </div>
+          </ZeroState>
+        </div>
+      );
+    }
   }
 
   /**
@@ -166,7 +166,7 @@ class DocumentList extends React.Component {
             activeDocumentView={this.props.view}
             {...this.props} />
         </div>
-				{this.renderZeroState()}
+        {this.renderZeroState()}
         {this.renderContent()}
         {this.renderInsertModal()}
       </div>
@@ -195,6 +195,7 @@ DocumentList.propTypes = {
   updateJsonDoc: PropTypes.func,
   version: PropTypes.string.isRequired,
   viewChanged: PropTypes.func.isRequired,
+  docs: PropTypes.array,
   ns: PropTypes.string,
   tz: PropTypes.string
 };

--- a/src/components/document-list.jsx
+++ b/src/components/document-list.jsx
@@ -1,8 +1,10 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { ObjectID as ObjectId } from 'bson';
-import { StatusRow } from 'hadron-react-components';
+import { StatusRow, ZeroState } from 'hadron-react-components';
+import { TextButton } from 'hadron-react-buttons';
 import InsertDocumentDialog from 'components/insert-document-dialog';
+import ZeroGraphic from './zero-graphic';
 import DocumentListView from 'components/document-list-view';
 import DocumentJsonView from 'components/document-json-view';
 import DocumentTableView from 'components/document-table-view';
@@ -10,6 +12,10 @@ import Toolbar from 'components/toolbar';
 
 import './index.less';
 import './ag-grid-dist.css';
+
+const HEADER = "This collection has no data";
+
+const SUBTEXT = "It only takes a few seconds to import data from a JSON or CSV file";
 
 /**
  * Component for the entire document list.
@@ -117,6 +123,33 @@ class DocumentList extends React.Component {
   }
 
   /**
+   * Render ZeroState view when no documents are present.
+   *
+   * @returns {React.Component} The query bar.
+   */
+  renderZeroState() {
+    const editableClass = !this.props.isEditable ? 'disabled' : '';
+
+		if (this.props.docs.length === 0) {
+			return (
+				<div className="document-list-zero-state">
+					<ZeroGraphic />
+					<ZeroState header={HEADER} subtext={SUBTEXT}>
+						<div className="document-list-zero-state-action">
+							<div>
+								<TextButton
+									className={`btn btn-primary btn-lg ${editableClass}`}
+									text="ImportData"
+									clickHandler={this.props.openImportFileDialog} />
+							</div>
+						</div>
+					</ZeroState>
+				</div>
+			);
+		}
+  }
+
+  /**
    * Render the document list.
    *
    * @returns {React.Component} The document list.
@@ -133,6 +166,7 @@ class DocumentList extends React.Component {
             activeDocumentView={this.props.view}
             {...this.props} />
         </div>
+				{this.renderZeroState()}
         {this.renderContent()}
         {this.renderInsertModal()}
       </div>

--- a/src/components/document-list.less
+++ b/src/components/document-list.less
@@ -1,3 +1,5 @@
+@import (reference) "~less/compass/_theme.less";
+
 .document-list {
   padding: 0 15px;
   list-style: none;
@@ -13,6 +15,24 @@
     &:last-child {
       margin-bottom: 0;
       border-bottom: 0 solid transparent;
+    }
+  }
+
+  &-zero-state {
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    padding-top: 135px;
+
+    &-action {
+      display: flex;
+      flex-direction: column;
+    }
+
+    &-graphic {
+      width: 75px;
     }
   }
 

--- a/src/components/document-list.less
+++ b/src/components/document-list.less
@@ -28,6 +28,11 @@
 
     &-container {
       display: flex;
+
+      .document-list-action-bar-export-collection {
+        padding: 0 5px;
+        margin-right: 18px;
+      }
     }
 
     &-insert-data-title {
@@ -97,12 +102,17 @@
         }
       }
     }
+
+    &-refresh {
+      i {
+        padding-right: 5px;
+      }
+    }
   }
 }
 
 .option-selector {
   margin-right: 5px;
-  padding-right: 13px;
 
   #insert-data-dropdown {
     display: flex;

--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { ViewSwitcher } from 'hadron-react-components';
-import { AnimatedIconTextButton } from 'hadron-react-buttons';
+import { ViewSwitcher, Tooltip } from 'hadron-react-components';
+import { AnimatedIconTextButton, IconButton } from 'hadron-react-buttons';
 
 const BASE_CLASS = 'document-list';
 const ACTION_BAR_CLASS = `${BASE_CLASS}-action-bar`;
@@ -12,6 +12,7 @@ const PAGINATION_CLASS = `${ACTION_BAR_CLASS}-pagination`;
 const VIEW_SWITCHER_CLASS = `${ACTION_BAR_CLASS}-view-switcher`;
 const INSERT_DATA = `btn-primary ${ACTION_BAR_CLASS}-insert-data`;
 const INSERT_DATA_TITLE = `${ACTION_BAR_CLASS}-insert-data-title`;
+const EXPORT_COLLECTION_CLASS = `${ACTION_BAR_CLASS}-export-collection`;
 
 /**
  * Component for the CRUD toolbar.
@@ -104,6 +105,23 @@ class Toolbar extends React.Component {
     }
   }
 
+  renderExportButton() {
+    return (
+      <div
+        data-for="export-collection-tooltip"
+        data-tip="Export Collection"
+        data-place="top">
+        <IconButton
+          title="ExportCollection"
+          className={`${EXPORT_COLLECTION_CLASS} btn-default btn-xs`}
+          iconClassName={`${EXPORT_COLLECTION_CLASS}-button fa fa-upload`}
+          dataTestId="export-collection-button"
+          clickHandler={this.props.openExportFileDialog} />
+        <Tooltip id="export-collection-tooltip" />
+      </div>
+    );
+  }
+
   /**
    * If we are on the documents tab, just display the count and insert button.
    *
@@ -115,6 +133,7 @@ class Toolbar extends React.Component {
         <div className={ACTION_BAR_CLASS}>
           <div className={CONTAINER_CLASS}>
             {this.renderInsertButton()}
+            {this.renderExportButton()}
             <div className={VIEW_SWITCHER_CLASS}>
               <ViewSwitcher
                 label="View"
@@ -137,6 +156,7 @@ class Toolbar extends React.Component {
                 dataTestId="refresh-documents-button"
                 className="btn btn-default btn-xs sampling-message-refresh-documents"
                 iconClassName="fa fa-repeat"
+                text="REFRESH"
                 animatingIconClassName="fa fa-refresh fa-spin"/>
             </div>
           </div>
@@ -155,6 +175,7 @@ Toolbar.propTypes = {
   getNextPage: PropTypes.func.isRequired,
   getPrevPage: PropTypes.func.isRequired,
   insertHandler: PropTypes.func,
+  openExportFileDialog: PropTypes.func,
   isExportable: PropTypes.bool.isRequired,
   page: PropTypes.number.isRequired,
   readonly: PropTypes.bool.isRequired,

--- a/src/components/toolbar.jsx
+++ b/src/components/toolbar.jsx
@@ -113,7 +113,7 @@ class Toolbar extends React.Component {
         data-place="top">
         <IconButton
           title="ExportCollection"
-          className={`${EXPORT_COLLECTION_CLASS} btn-default btn-xs`}
+          className={`${EXPORT_COLLECTION_CLASS} btn btn-default btn-xs`}
           iconClassName={`${EXPORT_COLLECTION_CLASS}-button fa fa-upload`}
           dataTestId="export-collection-button"
           clickHandler={this.props.openExportFileDialog} />
@@ -154,7 +154,7 @@ class Toolbar extends React.Component {
                 clickHandler={this.handleRefreshDocuments.bind(this)}
                 stopAnimationListenable={this.props.pageLoadedListenable}
                 dataTestId="refresh-documents-button"
-                className="btn btn-default btn-xs sampling-message-refresh-documents"
+                className="btn btn-default btn-xs"
                 iconClassName="fa fa-repeat"
                 text="REFRESH"
                 animatingIconClassName="fa fa-refresh fa-spin"/>

--- a/src/components/zero-graphic.jsx
+++ b/src/components/zero-graphic.jsx
@@ -13,27 +13,27 @@ class ZeroGraphic extends PureComponent {
    */
   render() {
     return (
-			<svg className="document-list-zero-state-graphic" xmlns="http://www.w3.org/2000/svg" width="38" height="48" viewBox="0 0 38 48">
-				<g fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" transform="translate(1 1)">
-					<polyline stroke="#116149" points="30 .002 30 6.002 36 6.002"/>
-					<polyline stroke="#116149" points="30 26.002 30 32.002 36 32.002"/>
-					<line y1=".002" y2="2.002" stroke="#116149"/>
-					<line y1="12.002" y2="14.002" stroke="#116149"/>
-					<polyline stroke="#116149" points="0 6.002 0 8.002 2 8.002"/>
-					<line y1="18.002" y2="20.002" stroke="#116149"/>
-					<line y1="24.002" y2="26.002" stroke="#116149"/>
-					<line y1="30.002" y2="32.002" stroke="#116149"/>
-					<polyline stroke="#116149" points="0 36.002 0 38.002 2 38.002"/>
-					<line x1="6" x2="8" y1="8.002" y2="8.002" stroke="#116149"/>
-					<line x1="12" x2="14" y1="8.002" y2="8.002" stroke="#116149"/>
-					<line x1="18" x2="20" y1="8.002" y2="8.002" stroke="#116149"/>
-					<line x1="6" x2="8" y1="38.002" y2="38.002" stroke="#116149"/>
-					<line x1="12" x2="14" y1="38.002" y2="38.002" stroke="#116149"/>
-					<line x1="18" x2="20" y1="38.002" y2="38.002" stroke="#116149"/>
-					<polygon stroke="#16CC62" points="36 20.002 20 20.002 20 .002 30 .002 36 6.002"/>
-					<polygon stroke="#16CC62" points="36 46.002 20 46.002 20 26.002 30 26.002 36 32.002"/>
-				</g>
-			</svg>
+      <svg className="document-list-zero-state-graphic" xmlns="http://www.w3.org/2000/svg" width="38" height="48" viewBox="0 0 38 48">
+        <g fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" transform="translate(1 1)">
+          <polyline stroke="#116149" points="30 .002 30 6.002 36 6.002"/>
+          <polyline stroke="#116149" points="30 26.002 30 32.002 36 32.002"/>
+          <line y1=".002" y2="2.002" stroke="#116149"/>
+          <line y1="12.002" y2="14.002" stroke="#116149"/>
+          <polyline stroke="#116149" points="0 6.002 0 8.002 2 8.002"/>
+          <line y1="18.002" y2="20.002" stroke="#116149"/>
+          <line y1="24.002" y2="26.002" stroke="#116149"/>
+          <line y1="30.002" y2="32.002" stroke="#116149"/>
+          <polyline stroke="#116149" points="0 36.002 0 38.002 2 38.002"/>
+          <line x1="6" x2="8" y1="8.002" y2="8.002" stroke="#116149"/>
+          <line x1="12" x2="14" y1="8.002" y2="8.002" stroke="#116149"/>
+          <line x1="18" x2="20" y1="8.002" y2="8.002" stroke="#116149"/>
+          <line x1="6" x2="8" y1="38.002" y2="38.002" stroke="#116149"/>
+          <line x1="12" x2="14" y1="38.002" y2="38.002" stroke="#116149"/>
+          <line x1="18" x2="20" y1="38.002" y2="38.002" stroke="#116149"/>
+          <polygon stroke="#16CC62" points="36 20.002 20 20.002 20 .002 30 .002 36 6.002"/>
+          <polygon stroke="#16CC62" points="36 46.002 20 46.002 20 26.002 30 26.002 36 32.002"/>
+        </g>
+      </svg>
     );
   }
 }

--- a/src/components/zero-graphic.jsx
+++ b/src/components/zero-graphic.jsx
@@ -1,0 +1,41 @@
+import React, { PureComponent } from 'react';
+
+/**
+ * The zero graphic.
+ */
+class ZeroGraphic extends PureComponent {
+  static displayName = 'ZeroGraphic';
+
+  /**
+   * Render the zero graphic.
+   *
+   * @returns {React.Component} The react component.
+   */
+  render() {
+    return (
+			<svg className="document-list-zero-state-graphic" xmlns="http://www.w3.org/2000/svg" width="38" height="48" viewBox="0 0 38 48">
+				<g fill="none" fillRule="evenodd" strokeLinecap="round" strokeLinejoin="round" strokeWidth="2" transform="translate(1 1)">
+					<polyline stroke="#116149" points="30 .002 30 6.002 36 6.002"/>
+					<polyline stroke="#116149" points="30 26.002 30 32.002 36 32.002"/>
+					<line y1=".002" y2="2.002" stroke="#116149"/>
+					<line y1="12.002" y2="14.002" stroke="#116149"/>
+					<polyline stroke="#116149" points="0 6.002 0 8.002 2 8.002"/>
+					<line y1="18.002" y2="20.002" stroke="#116149"/>
+					<line y1="24.002" y2="26.002" stroke="#116149"/>
+					<line y1="30.002" y2="32.002" stroke="#116149"/>
+					<polyline stroke="#116149" points="0 36.002 0 38.002 2 38.002"/>
+					<line x1="6" x2="8" y1="8.002" y2="8.002" stroke="#116149"/>
+					<line x1="12" x2="14" y1="8.002" y2="8.002" stroke="#116149"/>
+					<line x1="18" x2="20" y1="8.002" y2="8.002" stroke="#116149"/>
+					<line x1="6" x2="8" y1="38.002" y2="38.002" stroke="#116149"/>
+					<line x1="12" x2="14" y1="38.002" y2="38.002" stroke="#116149"/>
+					<line x1="18" x2="20" y1="38.002" y2="38.002" stroke="#116149"/>
+					<polygon stroke="#16CC62" points="36 20.002 20 20.002 20 .002 30 .002 36 6.002"/>
+					<polygon stroke="#16CC62" points="36 46.002 20 46.002 20 26.002 30 26.002 36 32.002"/>
+				</g>
+			</svg>
+    );
+  }
+}
+
+export default ZeroGraphic;

--- a/src/stores/crud-store.js
+++ b/src/stores/crud-store.js
@@ -533,6 +533,14 @@ const configureStore = (options = {}) => {
     },
 
     /**
+     * Open an import file dialog from compass-import-export-plugin.
+     * Emits a global app registry event the plugin listens to.
+     */
+    openExportFileDialog() {
+      this.localAppRegistry.emit('open-export');
+    },
+
+    /**
      * Switch between list and JSON views when inserting a document through Insert Document modal.
      *
      * Also modifies doc and jsonDoc states to keep accurate data for each view.


### PR DESCRIPTION
## Description
Zero-state will be present when no documents are present in a collection. `Import Data` button in this zero state will open `import-data` dialogue.

This PR also adds an `Export Collection` button to the crud toolbar, and adds `refresh` text to the refresh button.

## Motivation and Context
This doesn't look quite right in local context, but if you load it in compass, it looks like this: 
![Screen Shot 2019-10-29 at 11 15 28 AM](https://user-images.githubusercontent.com/8107784/67759724-455bb600-fa40-11e9-8d5b-2ad17bb569e7.png)

## Types of changes
- [x] Minor (non-breaking change which adds functionality)
