### PR TITLE
remove ag-header z-index to not overlap dropdown

### DIFF
--- a/src/components/ag-grid.less
+++ b/src/components/ag-grid.less
@@ -18,7 +18,6 @@
   &-header {
     background: #F5F6F7;
     box-shadow: 0 2px 10px 0 rgba(0,0,0,0.10), inset 0 -1px 0 0 #D7D7D7;
-    z-index: 5;
     &-cell {
       border: 0;
       line-height: 25px;


### PR DESCRIPTION
## Description
`Import Data` dropdown is currently hidden behind `ag-header` in table view
since its `z-index` is set to 5. Removing the z-index solves the issue.

Before:
![Screen Shot 2019-10-29 at 11 45 30 AM](https://user-images.githubusercontent.com/8107784/67760446-a46dfa80-fa41-11e9-856b-d2347e886f56.png)

After:
![Screen Shot 2019-10-29 at 11 45 37 AM](https://user-images.githubusercontent.com/8107784/67760474-b059bc80-fa41-11e9-8ac1-314cb787d42b.png)

## Open Questions
Would be awesome if someone else could double check this works for them as well!
I've so far tried:
1. scrolling down to make sure the header is sticky and overlaps the cells if
the cell list is large
![Screen Shot 2019-10-29 at 11 46 39 AM](https://user-images.githubusercontent.com/8107784/67760548-ccf5f480-fa41-11e9-9a3c-311b3eab70a2.png)

2. editing cells to make sure we still see the header and the edit pop-out.
![Screen Shot 2019-10-29 at 11 43 12 AM](https://user-images.githubusercontent.com/8107784/67760371-7ee0f100-fa41-11e9-9104-413578974b62.png)

Not sure if this could have been used for something else though!

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)