### PR TITLE
COMPASS-3806: edit and save int64 numbers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17420,6 +17420,46 @@
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        },
+        "loose-envify": {
+          "version": "1.4.0",
+          "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+          "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+          "dev": true,
+          "requires": {
+            "js-tokens": "^3.0.0 || ^4.0.0"
+          }
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "dev": true
+        },
+        "prop-types": {
+          "version": "15.7.2",
+          "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
+          "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
+          "dev": true,
+          "requires": {
+            "loose-envify": "^1.4.0",
+            "object-assign": "^4.1.1",
+            "react-is": "^16.8.1"
+          }
+        },
+        "react-is": {
+          "version": "16.13.1",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+          "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+          "dev": true
+        }
       }
     },
     "react-ace": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9045,9 +9045,9 @@
       "dev": true
     },
     "hadron-type-checker": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-5.0.0.tgz",
-      "integrity": "sha512-uYZxeAhz9DEzRkp4Gg/a32TXt5mnX9IPvr9cTiZPT1ogRZqmoypQsymfjyr1VD6q+eMznS4Z2h9kc6dpeijyxw==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/hadron-type-checker/-/hadron-type-checker-5.1.0.tgz",
+      "integrity": "sha512-HC+1yOYXgvZvQNvpkW4pxhHc1W35oD7d6aefbdjl6xNInPaEB0xqnFxQxrtndnIeg+EC9Khmb8dPY5HAq+2pqQ==",
       "requires": {
         "bson": "^4.0.3",
         "lodash": "^4.17.15"

--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "bson": "^4.0.3",
     "fast-json-parse": "^1.0.3",
     "hadron-document": "^6.0.0",
-    "hadron-type-checker": "^5.0.0",
+    "hadron-type-checker": "^5.1.0",
     "js-beautify": "^1.10.0",
     "lodash": "^4.17.15",
     "moment": "^2.18.1",

--- a/src/components/editor/index.js
+++ b/src/components/editor/index.js
@@ -32,6 +32,7 @@ export {
   Decimal128Editor,
   DoubleEditor,
   Int32Editor,
+  Int64Editor,
   NullEditor,
   UndefinedEditor,
   ObjectIdEditor

--- a/src/components/editor/index.js
+++ b/src/components/editor/index.js
@@ -2,6 +2,7 @@ import StandardEditor from './standard';
 import StringEditor from './string';
 import Decimal128Editor from './decimal128';
 import Int32Editor from './int32';
+import Int64Editor from './int64';
 import DoubleEditor from './double';
 import DateEditor from './date';
 import NullEditor from './null';
@@ -16,6 +17,7 @@ const init = (element, tz) => {
     'Date': new DateEditor(element, tz),
     'Double': new DoubleEditor(element),
     'Int32': new Int32Editor(element),
+    'Int64': new Int64Editor(element),
     'Null': new NullEditor(element),
     'Undefined': new UndefinedEditor(element),
     'ObjectId': new ObjectIdEditor(element)

--- a/src/components/editor/int64.js
+++ b/src/components/editor/int64.js
@@ -1,0 +1,62 @@
+import TypeChecker from 'hadron-type-checker';
+import { Element } from 'hadron-document';
+import StandardEditor from './standard';
+import chars from 'utils';
+
+/**
+ * CRUD editor for int32 values.
+ */
+class Int64Editor extends StandardEditor {
+  /**
+   * Create the editor with the element.
+   *
+   * @param {Element} element - The hadron document element.
+   */
+  constructor(element) {
+    super(element);
+  }
+
+  /**
+   * Complete the int64 edit by converting the valid string to a int64
+   * value or leaving as invalid.
+   */
+  complete() {
+    if (this.element.isCurrentTypeValid()) {
+      this.element.edit(TypeChecker.cast(this.element.currentValue, 'Int64'));
+    }
+  }
+
+  /**
+   * Edit Int64 element. Check if the value is a Int64 before setting typed
+   * up value.
+   *
+   * @param {Object} value - The new value.
+   */
+  edit(value) {
+    try {
+      TypeChecker.cast(value, 'Int64');
+      this.element.currentValue = value;
+      this.element.setValid();
+      this.element._bubbleUp(Element.Events.Edited);
+    } catch (error) {
+      this.element.setInvalid(value, this.element.currentType, error.message);
+    }
+  }
+
+  /**
+   * Get the number of characters the value should display.
+   *
+   * @param {Boolean} editMode - If the element is being edited.
+   *
+   * @returns {Number} The number of characters.
+   */
+  size() {
+    return chars(this.element.currentValue);
+  }
+
+  value() {
+    return this.element.currentValue;
+  }
+}
+
+export default Int64Editor;

--- a/src/components/editor/int64.spec.js
+++ b/src/components/editor/int64.spec.js
@@ -1,0 +1,159 @@
+import { Element } from 'hadron-document';
+import { Long } from 'bson';
+import { Int64Editor } from 'components/editor';
+
+describe('Int64Editor', () => {
+  describe('#start', () => {
+    const int64Value = Long.fromString('750');
+    const element = new Element('field', int64Value, false);
+
+    context('when the current type is not edited and is valid', () => {
+      const int64Editor = new Int64Editor(element);
+
+      before(() => {
+        int64Editor.start();
+      });
+
+      it('returns the number of characters', () => {
+        expect(int64Editor.size()).to.equal(3);
+      });
+
+      it('edits the element with the formatted value', () => {
+        expect(element.currentValue).to.equal(int64Value);
+      });
+
+      it('sets the current value as a valid value', () => {
+        expect(element.isCurrentTypeValid()).to.equal(true);
+      });
+    });
+
+    context('when the current type is not valid', () => {
+      const int64Editor = new Int64Editor(element);
+
+      before(() => {
+        int64Editor.start();
+        int64Editor.edit('cats cats not valid cats');
+        int64Editor.complete();
+        int64Editor.start();
+      });
+
+      it('returns the number of characters', () => {
+        expect(int64Editor.size()).to.equal(24);
+      });
+
+      it('edits the element with the formatted value', () => {
+        expect(element.currentValue).to.equal('cats cats not valid cats');
+      });
+
+      it('sets the invalid message', () => {
+        expect(element.invalidTypeMessage).to.equal('Value cats cats not valid cats is outside the valid Int64 range');
+      });
+    });
+  });
+
+  describe('#edit', () => {
+    const int64Value = Long.fromString('122');
+    const element = new Element('field', int64Value, false);
+
+    context('when the current value is edited to a valid int64', () => {
+      const int64Editor = new Int64Editor(element);
+      const validInt64 = Long.fromString('123');
+
+      before(() => {
+        int64Editor.start();
+        int64Editor.edit(validInt64);
+      });
+
+      it('returns the number of characters', () => {
+        expect(int64Editor.size()).to.equal(3);
+      });
+
+      it('edits the element with the formatted value', () => {
+        expect(element.currentValue).to.equal(validInt64);
+      });
+
+      it('sets the current value as a valid value', () => {
+        expect(element.isCurrentTypeValid()).to.equal(true);
+      });
+    });
+
+    context('when the current value is edited to an invalid int64', () => {
+      const int64Editor = new Int64Editor(element);
+
+      before(() => {
+        int64Editor.start();
+        int64Editor.edit('ceci n\'est pas un int64');
+      });
+
+      it('returns the number of characters', () => {
+        expect(int64Editor.size()).to.equal(23);
+      });
+
+      it('edits the element with the formatted value', () => {
+        expect(element.currentValue).to.equal('ceci n\'est pas un int64');
+      });
+
+      it('curent type is invalid', () => {
+        expect(element.isCurrentTypeValid()).to.equal(false);
+      });
+
+      it('sets the invalid message', () => {
+        expect(element.invalidTypeMessage).to.equal('Value ceci n\'est pas un int64 is outside the valid Int64 range');
+      });
+    });
+  });
+
+  describe('#complete', () => {
+    const int64Value = Long.fromString('123');
+    const element = new Element('field', int64Value, false);
+
+    context('when the current value is edited to a valid int64', () => {
+      const int64Editor = new Int64Editor(element);
+      const valid = Long.fromString('0');
+
+      before(() => {
+        int64Editor.start();
+        int64Editor.edit(valid);
+        int64Editor.complete();
+      });
+
+      it('returns the number of characters', () => {
+        expect(int64Editor.size()).to.equal(1);
+      });
+
+      it('edits the element with the formatted value', () => {
+        expect(element.currentValue).to.deep.equal(Long.fromString('0'));
+      });
+
+      it('sets the current value as a valid value', () => {
+        expect(element.isCurrentTypeValid()).to.equal(true);
+      });
+    });
+
+    context('when the current value is edited to an large int64 that is out of range', () => {
+      const int64Editor = new Int64Editor(element);
+
+      before(() => {
+        int64Editor.start();
+        int64Editor.edit('10223372036854775810');
+        int64Editor.complete();
+      });
+
+      it('returns the number of characters', () => {
+        expect(int64Editor.size()).to.equal(20);
+      });
+
+      it('edits the element with the formatted value', () => {
+        expect(element.currentValue).to.equal('10223372036854775810');
+      });
+
+      it('curent type is invalid', () => {
+        expect(element.isCurrentTypeValid()).to.equal(false);
+      });
+
+      it('sets the invalid message', () => {
+        expect(element.invalidTypeMessage).to.equal('Value 10223372036854775810 is outside the valid Int64 range');
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description
Allows editing and saving int64 numbers in crud editor.
This PR uses the updated `hadron-type-checker` that fixed ability to edit and update very large int64 numbers that are out of javascript number range but are still within valid int64 range. 

### Checklist
- [x] New tests and/or benchmarks are included
~- [ ] Documentation is changed or added~

## Dependents
This requires a PR to compass to update to latest compass-crud once this is published. This will also require CLOUD to update their compass-crud dependency to the latest version once this is published. 

## Types of changes
- [x] Patch (non-breaking change which fixes an issue)
