### PR TITLE
Fix a style issue where document-element covered partially by document action bar

### DIFF
--- a/src/components/document-actions.less
+++ b/src/components/document-actions.less
@@ -46,4 +46,10 @@
   &-left {
     float: left;
   }
+
+  &-left, &-right {
+    button {
+      z-index: 2;
+    }
+  }
 }

--- a/src/components/document-elements.less
+++ b/src/components/document-elements.less
@@ -6,6 +6,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
+  z-index: 1;
 
   .line-number {
     position: absolute;


### PR DESCRIPTION
On readonly document, the first line objectid cannot be selected because it's covered by document action bar
![image](https://user-images.githubusercontent.com/1433871/92302481-0cb13500-ef9f-11ea-9e5e-85036d89e41b.png)

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
Document element's style z-index is set by 1 to make it frontward and not to be covered by document action bar

### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [X] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
