### PR TITLE
Make table header styling not overlap in nested documents

### DIFF
--- a/src/components/ag-grid.less
+++ b/src/components/ag-grid.less
@@ -53,7 +53,6 @@
     }
     &-viewport {
       margin-right: 0!important;
-      margin-left: 30px;
     }
   }
   &-row  {
@@ -125,7 +124,7 @@
   }
   &-pinned-left {
     &-header {
-      position: absolute;
+      position: relative;
     }
   }
   &-body-viewport {

--- a/src/components/table-view-cell.less
+++ b/src/components/table-view-cell.less
@@ -128,6 +128,7 @@
 
     &-subtable-objectid {
       border-right: 3px solid #bfbfbe;
+      position: relative;
     }
   }
 }


### PR DESCRIPTION
Fixes table view header fields overlapping:

## Before
<img width="1024" alt="Screen Shot 2020-09-28 at 1 32 07 PM" src="https://user-images.githubusercontent.com/1791149/94428445-f9098080-0190-11eb-86c0-790d39ee57fc.png">


## After
<img width="1016" alt="Screen Shot 2020-09-28 at 1 44 56 PM" src="https://user-images.githubusercontent.com/1791149/94428441-f60e9000-0190-11eb-8f4a-31c3efc344b1.png">
