### PR TITLE
Fix document actions covering json editor first line

### DIFF
--- a/src/components/document-actions.less
+++ b/src/components/document-actions.less
@@ -3,6 +3,12 @@
   width: 100%;
   top: 15px;
   padding: 0px 20px 0px 20px;
+  pointer-events: none;
+
+  &-left,
+  &-right {
+    pointer-events: all;
+  }
 
   &-button {
     visibility: hidden;
@@ -32,8 +38,6 @@
   }
 
   &-expand-button {
-    adding: 0px 5px 0px 5px;
-
     .fa {
       height: 12px;
       width: 12px;
@@ -43,13 +47,8 @@
   &-right {
     float: right;
   }
+
   &-left {
     float: left;
-  }
-
-  &-left, &-right {
-    button {
-      z-index: 2;
-    }
   }
 }

--- a/src/components/document-elements.less
+++ b/src/components/document-elements.less
@@ -6,7 +6,6 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: 100%;
-  z-index: 1;
 
   .line-number {
     position: absolute;
@@ -38,6 +37,7 @@
       .btn {
         border-color: #8c8c8c;
       }
+
       .caret {
         visibility: visible;
       }
@@ -51,4 +51,3 @@
     }
   }
 }
-


### PR DESCRIPTION
Fixes https://github.com/mongodb-js/compass/issues/2008 in the json view - it's already fixed in the default crud view.

New behavior (can click on first line in json view and expand/collapse it):
![first item accessible ](https://user-images.githubusercontent.com/1791149/95866518-4af0ff80-0d68-11eb-8640-5d26630c130d.gif)
