### PR TITLE
COMPASS-4453: Fix document new field update prompt

### DIFF
--- a/src/utils/document.js
+++ b/src/utils/document.js
@@ -79,7 +79,14 @@ export const getOriginalKeysAndValuesForFieldsThatWereUpdated = (doc) => {
       if (element.isAdded() && element.currentKey !== '') {
         // Using `.currentKey` to ensure we see if the new field was
         // added with a different value in the background.
-        object[element.currentKey] = element.generateOriginalObject();
+        object[element.currentKey] = {
+          $in: [
+            {
+              $exists: false
+            },
+            element.generateOriginalObject()
+          ]
+        };
       }
     }
   }

--- a/src/utils/document.js
+++ b/src/utils/document.js
@@ -77,16 +77,9 @@ export const getOriginalKeysAndValuesForFieldsThatWereUpdated = (doc) => {
         object[element.key] = element.generateOriginalObject();
       }
       if (element.isAdded() && element.currentKey !== '') {
-        // Using `.currentKey` to ensure we see if the new field was
-        // added with a different value in the background.
-        object[element.currentKey] = {
-          $in: [
-            {
-              $exists: false
-            },
-            element.generateOriginalObject()
-          ]
-        };
+        // When a new field is added, check if that field
+        //  was already added in the background.
+        object[element.currentKey] = { $exists: false };
       }
     }
   }

--- a/src/utils/document.js
+++ b/src/utils/document.js
@@ -78,7 +78,7 @@ export const getOriginalKeysAndValuesForFieldsThatWereUpdated = (doc) => {
       }
       if (element.isAdded() && element.currentKey !== '') {
         // When a new field is added, check if that field
-        //  was already added in the background.
+        // was already added in the background.
         object[element.currentKey] = { $exists: false };
       }
     }

--- a/src/utils/document.spec.js
+++ b/src/utils/document.spec.js
@@ -417,9 +417,16 @@ describe('document utils', () => {
         doc.insertEnd('pineapple', 'hat');
       });
 
-      it('includes the new element in the object', function() {
+      it('includes a check that the new element doesnt exist or exists with the same value', function() {
         expect(getOriginalKeysAndValuesForFieldsThatWereUpdated(doc)).to.deep.equal({
-          pineapple: 'hat'
+          pineapple: {
+            $in: [
+              {
+                $exists: false
+              },
+              'hat'
+            ]
+          }
         });
       });
     });

--- a/src/utils/document.spec.js
+++ b/src/utils/document.spec.js
@@ -420,12 +420,7 @@ describe('document utils', () => {
       it('includes a check that the new element doesnt exist or exists with the same value', function() {
         expect(getOriginalKeysAndValuesForFieldsThatWereUpdated(doc)).to.deep.equal({
           pineapple: {
-            $in: [
-              {
-                $exists: false
-              },
-              'hat'
-            ]
+            $exists: false
           }
         });
       });


### PR DESCRIPTION
COMPASS-4453

This PR makes it so we don't block an update when a new field is added to a document.

Before:
![new field shows update blocked confirm](https://user-images.githubusercontent.com/1791149/96007163-85c56700-0e3e-11eb-9722-2af2d0135f89.gif)

After:
![no block on newfield](https://user-images.githubusercontent.com/1791149/96007152-81994980-0e3e-11eb-8fef-11b666503838.gif)

