### PR TITLE
COMPASS-4423: Multi line string input editing

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -18,7 +18,6 @@ module.exports = {
       plugin: path.join(project.path.src, 'index.js'),
       stores: path.join(project.path.src, 'stores'),
       storybook: project.path.storybook,
-      utils: path.join(project.path.src, 'utils'),
       'react-dom': '@hot-loader/react-dom'
     }
   },

--- a/src/components/editable-element-field.less
+++ b/src/components/editable-element-field.less
@@ -3,7 +3,7 @@
   border: none;
   padding-left: 1px;
   -webkit-user-select: text;
-  max-width: 15vw;
+  max-width: 15%;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/src/components/editable-element-value.less
+++ b/src/components/editable-element-value.less
@@ -6,7 +6,6 @@
   white-space: nowrap;
   overflow: hidden;
   max-width: ~"calc(85vw - 260px);";
-  width: fit-content;
 
   &-tooltip {
     height: 20px !important;
@@ -16,17 +15,11 @@
   }
 
   &-is-string {
-    // white-space: pre-line;
-    // word-break: break-all;
     padding-right: 0px;
-    min-height: 17px;
+    height: 17px;
     overflow-y: scroll;
-    // max-height: 10vh;
+    max-height: 50vh;
   }
-
-  // &-is-editing &-is-string {
-  //   max-height: 40vh;
-  // }
 
   &-is-int32 {
     color: #145a32;

--- a/src/components/editable-element-value.less
+++ b/src/components/editable-element-value.less
@@ -6,6 +6,7 @@
   white-space: nowrap;
   overflow: hidden;
   max-width: ~"calc(85vw - 260px);";
+  width: fit-content;
 
   &-tooltip {
     height: 20px !important;
@@ -15,10 +16,17 @@
   }
 
   &-is-string {
-    white-space: pre-line;
-    word-break: break-all;
+    // white-space: pre-line;
+    // word-break: break-all;
     padding-right: 0px;
+    min-height: 17px;
+    overflow-y: scroll;
+    // max-height: 10vh;
   }
+
+  // &-is-editing &-is-string {
+  //   max-height: 40vh;
+  // }
 
   &-is-int32 {
     color: #145a32;

--- a/src/components/editable-element-value.less
+++ b/src/components/editable-element-value.less
@@ -4,8 +4,7 @@
   padding-left: 1px;
   text-overflow: ellipsis;
   white-space: nowrap;
-  overflow: hidden;
-  max-width: ~"calc(85vw - 260px);";
+  max-width: ~"calc(100% - 6px)";
 
   &-tooltip {
     height: 20px !important;
@@ -15,9 +14,9 @@
   }
 
   &-is-string {
-    padding-right: 0px;
+    padding: 0px;
     height: 17px;
-    overflow-y: scroll;
+    overflow: auto;
     max-height: 50vh;
   }
 
@@ -69,7 +68,8 @@
   }
 
   &-wrapper {
-    flex-grow: 3;
+    flex-grow: 1;
+    overflow: hidden;
 
     &-is-string {
       color: steelblue;

--- a/src/components/editable-element.less
+++ b/src/components/editable-element.less
@@ -4,6 +4,7 @@
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: center;
+  position: relative;
 
   &-field {
     display: inline-block;

--- a/src/components/editable-key.jsx
+++ b/src/components/editable-key.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import chars from 'utils';
+import { fieldStringLen } from '../utils';
 
 /* eslint no-return-assign:0 */
 
@@ -105,7 +105,7 @@ class EditableKey extends React.Component {
    */
   handleChange(evt) {
     const value = evt.target.value;
-    this._node.size = chars(value);
+    this._node.size = fieldStringLen(value);
     if (this.isEditable()) {
       if (this.element.isDuplicateKey(value)) {
         this.setState({ duplicate: true });
@@ -203,13 +203,14 @@ class EditableKey extends React.Component {
    * @returns {React.Component} The element component.
    */
   render() {
-    const length = (chars(this.renderValue()) * 6.625) + 6.625;
+    // const length = (chars(this.renderValue()) * 6.625) + 6.625;
+    const length = fieldStringLen(this.renderValue()) + 0.5;
     return (
       <input
         className={this.style()}
         ref={(c) => this._node = c}
         type="text"
-        style={{ width: `${length}px` }}
+        style={{ width: `${length}ch` }}
         tabIndex={this.isEditable() ? 0 : -1}
         onBlur={this.handleBlur.bind(this)}
         onFocus={this.handleFocus.bind(this)}
@@ -217,7 +218,8 @@ class EditableKey extends React.Component {
         onKeyDown={this.handleKeyDown.bind(this)}
         onKeyUp={this.handleKeyUp.bind(this)}
         value={this.renderValue()}
-        title={this.renderTitle()} />
+        title={this.renderTitle()}
+      />
     );
   }
 }

--- a/src/components/editable-key.jsx
+++ b/src/components/editable-key.jsx
@@ -203,7 +203,6 @@ class EditableKey extends React.Component {
    * @returns {React.Component} The element component.
    */
   render() {
-    // const length = (chars(this.renderValue()) * 6.625) + 6.625;
     const length = fieldStringLen(this.renderValue()) + 0.5;
     return (
       <input

--- a/src/components/editable-key.spec.js
+++ b/src/components/editable-key.spec.js
@@ -5,6 +5,20 @@ import EditableKey from 'components/editable-key';
 
 describe('<EditableKey />', () => {
   describe('#render', () => {
+    context('when the key exists', () => {
+      let wrapper;
+
+      before(() => {
+        const parentElement = new Element('parent', {}, false);
+        const element = new Element('key', 1, true, parentElement);
+        wrapper = mount(<EditableKey element={element} isFocused={false} />);
+      });
+
+      it('has a width corresponding to the key string length', () => {
+        expect(wrapper.find('input').prop('style').width).to.equal('3.5ch');
+      });
+    });
+
     context('when the key is for an added element', () => {
       context('when the key is an array element', () => {
         let wrapper;

--- a/src/components/editable-value.jsx
+++ b/src/components/editable-value.jsx
@@ -5,8 +5,6 @@ import initEditors from 'components/editor';
 
 import { STRING_TYPE } from './editor/string';
 
-/* eslint no-return-assign:0 */
-
 const ESC_KEY_CODE = 27;
 const TAB_KEY_CODE = 9;
 const ENTER_KEY_CODE = 13;
@@ -243,7 +241,6 @@ class EditableValue extends React.Component {
    * @returns {React.Component} The element component.
    */
   render() {
-    // const length = (this.editor().size(this.state.editing) * 6.625) + 6.625;
     const length = this.editor().size(this.state.editing) + (this.state.editing ? 1 : 0.4);
     return (
       <span className={this.wrapperStyle()}>
@@ -257,7 +254,7 @@ class EditableValue extends React.Component {
           <textarea
             data-tip=""
             data-for={this.element.uuid}
-            ref={(c) => this._node = c}
+            ref={(c) => { this._node = c; }}
             type="text"
             className={this.style()}
             onBlur={this.handleBlur.bind(this)}
@@ -265,14 +262,20 @@ class EditableValue extends React.Component {
             onChange={this.handleChange.bind(this)}
             onKeyDown={this.handleKeyDown.bind(this)}
             onPaste={this.handlePaste.bind(this)}
-            style={{ width: `${length}ch` }}
+            style={(this.element.currentValue || '').includes('\n') ? {
+              minHeight: '77px',
+              width: '85vw' // Scale to max width when it's a multi-line string.
+            } : {
+              minHeight: '17px',
+              width: `${length}ch`
+            }}
             value={this.editor().value(this.state.editing)}
           />
         ) : (
           <input
             data-tip=""
             data-for={this.element.uuid}
-            ref={(c) => this._node = c}
+            ref={(c) => { this._node = c; }}
             type="text"
             className={this.style()}
             onBlur={this.handleBlur.bind(this)}

--- a/src/components/editable-value.jsx
+++ b/src/components/editable-value.jsx
@@ -113,7 +113,7 @@ class EditableValue extends React.Component {
       // we don't want to choose the next value.
       if (!(this.element.currentType === STRING_TYPE && evt.shiftKey)) {
         if (this.element.nextElement) {
-          // need to force the focus.
+          // Focus the next element.
           this._node.parentNode.parentNode.nextSibling.childNodes[2].focus();
         }
         this.simulateTab(evt);

--- a/src/components/editable-value.jsx
+++ b/src/components/editable-value.jsx
@@ -113,9 +113,7 @@ class EditableValue extends React.Component {
     } else if (evt.keyCode === ENTER_KEY_CODE) {
       // When we're editing a string and shift is clicked with enter
       // we don't want to choose the next value.
-      console.log('is enter');
       if (!(this.element.currentType === STRING_TYPE && evt.shiftKey)) {
-        console.log('here');
         if (this.element.nextElement) {
           // need to force the focus.
           this._node.parentNode.parentNode.nextSibling.childNodes[2].focus();

--- a/src/components/editable-value.jsx
+++ b/src/components/editable-value.jsx
@@ -3,12 +3,13 @@ import PropTypes from 'prop-types';
 import { Tooltip } from 'hadron-react-components';
 import initEditors from 'components/editor';
 
+import { STRING_TYPE } from './editor/string';
+
 /* eslint no-return-assign:0 */
 
-/**
- * Escape key code.
- */
-const ESC = 27;
+const ESC_KEY_CODE = 27;
+const TAB_KEY_CODE = 9;
+const ENTER_KEY_CODE = 13;
 
 /**
  * The editing class constant.
@@ -100,21 +101,27 @@ class EditableValue extends React.Component {
    * @param {Event} evt - The event.
    */
   handleKeyDown(evt) {
-    if (evt.keyCode === 9 && !evt.shiftKey) {
+    if (evt.keyCode === TAB_KEY_CODE && !evt.shiftKey) {
       this.simulateTab(evt);
-    } else if (evt.keyCode === ESC) {
+    } else if (evt.keyCode === ESC_KEY_CODE) {
       const value = evt.target.value;
       if (value.length === 0 && this.element.currentKey.length === 0) {
         this.element.remove();
       } else {
         this._node.blur();
       }
-    } else if (evt.keyCode === 13) {
-      if (this.element.nextElement) {
-        // need to force the focus.
-        this._node.parentNode.parentNode.nextSibling.childNodes[2].focus();
+    } else if (evt.keyCode === ENTER_KEY_CODE) {
+      // When we're editing a string and shift is clicked with enter
+      // we don't want to choose the next value.
+      console.log('is enter');
+      if (!(this.element.currentType === STRING_TYPE && evt.shiftKey)) {
+        console.log('here');
+        if (this.element.nextElement) {
+          // need to force the focus.
+          this._node.parentNode.parentNode.nextSibling.childNodes[2].focus();
+        }
+        this.simulateTab(evt);
       }
-      this.simulateTab(evt);
     }
   }
 
@@ -238,27 +245,47 @@ class EditableValue extends React.Component {
    * @returns {React.Component} The element component.
    */
   render() {
-    const length = (this.editor().size(this.state.editing) * 6.625) + 6.625;
+    // const length = (this.editor().size(this.state.editing) * 6.625) + 6.625;
+    const length = this.editor().size(this.state.editing) + (this.state.editing ? 1 : 0.4);
     return (
       <span className={this.wrapperStyle()}>
         <Tooltip
           id={this.element.uuid}
           className="editable-element-value-tooltip"
           border
-          getContent={() => { return this.element.invalidTypeMessage; }}/>
-        <input
-          data-tip=""
-          data-for={this.element.uuid}
-          ref={(c) => this._node = c}
-          type="text"
-          style={{ width: `${length}px` }}
-          className={this.style()}
-          onBlur={this.handleBlur.bind(this)}
-          onFocus={this.handleFocus.bind(this)}
-          onChange={this.handleChange.bind(this)}
-          onKeyDown={this.handleKeyDown.bind(this)}
-          onPaste={this.handlePaste.bind(this)}
-          value={this.editor().value(this.state.editing)} />
+          getContent={() => { return this.element.invalidTypeMessage; }}
+        />
+        {this.element.currentType === STRING_TYPE ? (
+          <textarea
+            data-tip=""
+            data-for={this.element.uuid}
+            ref={(c) => this._node = c}
+            type="text"
+            className={this.style()}
+            onBlur={this.handleBlur.bind(this)}
+            onFocus={this.handleFocus.bind(this)}
+            onChange={this.handleChange.bind(this)}
+            onKeyDown={this.handleKeyDown.bind(this)}
+            onPaste={this.handlePaste.bind(this)}
+            style={{ width: `${length}ch` }}
+            value={this.editor().value(this.state.editing)}
+          />
+        ) : (
+          <input
+            data-tip=""
+            data-for={this.element.uuid}
+            ref={(c) => this._node = c}
+            type="text"
+            className={this.style()}
+            onBlur={this.handleBlur.bind(this)}
+            onFocus={this.handleFocus.bind(this)}
+            onChange={this.handleChange.bind(this)}
+            onKeyDown={this.handleKeyDown.bind(this)}
+            onPaste={this.handlePaste.bind(this)}
+            style={{ width: `${length}ch` }}
+            value={this.editor().value(this.state.editing)}
+          />
+        )}
       </span>
     );
   }

--- a/src/components/editable-value.jsx
+++ b/src/components/editable-value.jsx
@@ -264,7 +264,7 @@ class EditableValue extends React.Component {
             onPaste={this.handlePaste.bind(this)}
             style={(this.element.currentValue || '').includes('\n') ? {
               minHeight: '77px',
-              width: '85vw' // Scale to max width when it's a multi-line string.
+              width: '100%' // Scale to max width when it's a multi-line string.
             } : {
               minHeight: '17px',
               width: `${length}ch`

--- a/src/components/editable-value.spec.js
+++ b/src/components/editable-value.spec.js
@@ -43,6 +43,20 @@ describe('<EditableValue />', () => {
       });
     });
 
+    context('when the value not being editing', () => {
+      let wrapper;
+
+      before(() => {
+        const parentElement = new Element('parent', {}, false);
+        const element = new Element('name', 'test', false, parentElement);
+        wrapper = mount(<EditableValue element={element} isFocused={false} tz="UTC" version="3.6.0" />);
+      });
+
+      it('has a width equal to the amount of characters + 0.4', () => {
+        expect(wrapper.find('textarea').prop('style').width).to.equal('4.4ch');
+      });
+    });
+
     context('when the value is a string type and its being editing', () => {
       let wrapper;
 
@@ -65,7 +79,7 @@ describe('<EditableValue />', () => {
         expect(wrapper.find('textarea').prop('style').minHeight).to.equal('17px');
       });
 
-      it('has a width equal to the amount of characters', () => {
+      it('has a width equal to the amount of characters + 1', () => {
         expect(wrapper.find('textarea').prop('style').width).to.equal('5ch');
       });
     });

--- a/src/components/editable-value.spec.js
+++ b/src/components/editable-value.spec.js
@@ -42,5 +42,69 @@ describe('<EditableValue />', () => {
         expect(input).to.not.equal(document.activeElement);
       });
     });
+
+    context('when the value is a string type and its being editing', () => {
+      let wrapper;
+
+      before(() => {
+        const parentElement = new Element('parent', {}, false);
+        const element = new Element('name', 'test', false, parentElement);
+        wrapper = mount(<EditableValue element={element} isFocused={false} tz="UTC" version="3.6.0" />);
+        wrapper.setState({ editing: true });
+      });
+
+      it('does not an input element', () => {
+        expect(wrapper.find('input')).to.not.be.present();
+      });
+
+      it('shows a textarea for input', () => {
+        expect(wrapper.find('textarea')).to.be.present();
+      });
+
+      it('has a minHeight of 17px', () => {
+        expect(wrapper.find('textarea').prop('style').minHeight).to.equal('17px');
+      });
+
+      it('has a width equal to the amount of characters', () => {
+        expect(wrapper.find('textarea').prop('style').width).to.equal('5ch');
+      });
+    });
+
+    context('when the value is not a string type and its being edited', () => {
+      let wrapper;
+
+      before(() => {
+        const parentElement = new Element('parent', {}, false);
+        const element = new Element('name', 333, false, parentElement);
+        wrapper = mount(<EditableValue element={element} isFocused={false} tz="UTC" version="3.6.0" />);
+      });
+
+      it('does not show a textarea for input', () => {
+        expect(wrapper.find('textarea')).to.not.be.present();
+      });
+
+      it('shows an input field for input', () => {
+        expect(wrapper.find('input')).to.be.present();
+      });
+    });
+
+    context('when the value is a multi-line string type and its being editing', () => {
+      let wrapper;
+
+      before(() => {
+        const parentElement = new Element('parent', {}, false);
+        const element = new Element('name', 'test\n\nok', false, parentElement);
+        wrapper = mount(<EditableValue element={element} isFocused={false} tz="UTC" version="3.6.0" />);
+        wrapper.setState({ editing: true });
+      });
+
+      it('has a minHeight of 76px', () => {
+        expect(wrapper.find('textarea').prop('style').minHeight).to.equal('77px');
+      });
+
+      it('has a width of 85vw', () => {
+        expect(wrapper.find('textarea').prop('style').width).to.equal('85vw');
+      });
+    });
   });
 });

--- a/src/components/editable-value.spec.js
+++ b/src/components/editable-value.spec.js
@@ -116,8 +116,8 @@ describe('<EditableValue />', () => {
         expect(wrapper.find('textarea').prop('style').minHeight).to.equal('77px');
       });
 
-      it('has a width of 85vw', () => {
-        expect(wrapper.find('textarea').prop('style').width).to.equal('85vw');
+      it('has a width of 100%', () => {
+        expect(wrapper.find('textarea').prop('style').width).to.equal('100%');
       });
     });
   });

--- a/src/components/editor/date.js
+++ b/src/components/editor/date.js
@@ -1,7 +1,7 @@
 import moment from 'moment-timezone';
 import TypeChecker from 'hadron-type-checker';
 import { Element } from 'hadron-document';
-import chars from 'utils';
+import { fieldStringLen } from '../../utils';
 import StandardEditor from './standard';
 
 /**
@@ -64,9 +64,9 @@ class DateEditor extends StandardEditor {
   size(editMode) {
     const value = this.element.currentValue;
     if (editMode) {
-      return chars(value);
+      return fieldStringLen(value);
     }
-    return this.element.isCurrentTypeValid() ? chars(this._formattedValue()) : chars(value);
+    return this.element.isCurrentTypeValid() ? fieldStringLen(this._formattedValue()) : fieldStringLen(value);
   }
 
   /**

--- a/src/components/editor/decimal128.js
+++ b/src/components/editor/decimal128.js
@@ -1,7 +1,6 @@
 import TypeChecker from 'hadron-type-checker';
 import { Element } from 'hadron-document';
 import StandardEditor from './standard';
-import chars from 'utils';
 
 /**
  * CRUD editor for decimal128 values.
@@ -41,17 +40,6 @@ class Decimal128Editor extends StandardEditor {
     } catch (error) {
       this.element.setInvalid(value, this.element.currentType, error.message);
     }
-  }
-
-  /**
-   * Get the number of characters the value should display.
-   *
-   * @param {Boolean} editMode - If the element is being edited.
-   *
-   * @returns {Number} The number of characters.
-   */
-  size() {
-    return chars(this.element.currentValue);
   }
 }
 

--- a/src/components/editor/double.js
+++ b/src/components/editor/double.js
@@ -1,7 +1,7 @@
 import TypeChecker from 'hadron-type-checker';
 import { Element } from 'hadron-document';
 import StandardEditor from './standard';
-import chars from 'utils';
+import { fieldStringLen } from '../../utils';
 
 /**
  * CRUD editor for double values.
@@ -55,7 +55,7 @@ class DoubleEditor extends StandardEditor {
    * @returns {Number} The number of characters.
    */
   size() {
-    return chars(this.element.currentValue.value);
+    return fieldStringLen(this.element.currentValue.value);
   }
 }
 

--- a/src/components/editor/int32.js
+++ b/src/components/editor/int32.js
@@ -1,4 +1,4 @@
-import chars from 'utils';
+import { fieldStringLen } from '../../utils';
 import StandardEditor from './standard';
 
 /**
@@ -22,7 +22,7 @@ class Int32Editor extends StandardEditor {
    * @returns {Number} The number of characters.
    */
   size() {
-    return chars(this.element.currentValue.valueOf());
+    return fieldStringLen(this.element.currentValue.valueOf());
   }
 }
 

--- a/src/components/editor/int64.js
+++ b/src/components/editor/int64.js
@@ -1,7 +1,6 @@
 import TypeChecker from 'hadron-type-checker';
 import { Element } from 'hadron-document';
 import StandardEditor from './standard';
-import chars from 'utils';
 
 /**
  * CRUD editor for int32 values.
@@ -41,21 +40,6 @@ class Int64Editor extends StandardEditor {
     } catch (error) {
       this.element.setInvalid(value, this.element.currentType, error.message);
     }
-  }
-
-  /**
-   * Get the number of characters the value should display.
-   *
-   * @param {Boolean} editMode - If the element is being edited.
-   *
-   * @returns {Number} The number of characters.
-   */
-  size() {
-    return chars(this.element.currentValue);
-  }
-
-  value() {
-    return this.element.currentValue;
   }
 }
 

--- a/src/components/editor/objectid.js
+++ b/src/components/editor/objectid.js
@@ -1,17 +1,19 @@
 import TypeChecker from 'hadron-type-checker';
 import { Element } from 'hadron-document';
 
+import StandardEditor from './standard';
+
 /**
  * CRUD editor for object id values.
  */
-class ObjectIdEditor {
+class ObjectIdEditor extends StandardEditor {
   /**
    * Create the editor with the element.
    *
    * @param {Element} element - The hadron document element.
    */
   constructor(element) {
-    this.element = element;
+    super(element);
   }
 
   /**

--- a/src/components/editor/objectid.js
+++ b/src/components/editor/objectid.js
@@ -1,6 +1,5 @@
 import TypeChecker from 'hadron-type-checker';
 import { Element } from 'hadron-document';
-import chars from 'utils';
 
 /**
  * CRUD editor for object id values.
@@ -42,30 +41,12 @@ class ObjectIdEditor {
   }
 
   /**
-   * Get the number of characters the value should display.
-   *
-   * @returns {Number} The number of characters.
-   */
-  size() {
-    return chars(this.element.currentValue);
-  }
-
-  /**
    * Start the object id edit.
    */
   start() {
     if (this.element.isCurrentTypeValid()) {
       this.edit(String(this.element.currentValue));
     }
-  }
-
-  /**
-   * Get the value being edited.
-   *
-   * @returns {String} The value.
-   */
-  value() {
-    return this.element.currentValue;
   }
 }
 

--- a/src/components/editor/standard.js
+++ b/src/components/editor/standard.js
@@ -1,6 +1,6 @@
 import TypeChecker from 'hadron-type-checker';
 import { Element } from 'hadron-document';
-import chars from 'utils';
+import { fieldStringLen } from '../../utils';
 
 /**
  * Regex to match an array or object string.
@@ -58,7 +58,7 @@ class StandardEditor {
    * @returns {Number} The number of characters.
    */
   size() {
-    return chars(this.element.currentValue);
+    return fieldStringLen(this.element.currentValue);
   }
 
   /**

--- a/src/components/editor/string.js
+++ b/src/components/editor/string.js
@@ -1,5 +1,6 @@
-import chars from 'utils';
 import StandardEditor from './standard';
+
+export const STRING_TYPE = 'String';
 
 /**
  * CRUD editor for string values.
@@ -12,17 +13,6 @@ class StringEditor extends StandardEditor {
    */
   constructor(element) {
     super(element);
-  }
-
-  /**
-   * Get the number of characters the value should display.
-   *
-   * @param {Boolean} editMode - If the element is being edited.
-   *
-   * @returns {Number} The number of characters.
-   */
-  size() {
-    return chars(this.element.currentValue);
   }
 }
 

--- a/src/components/editor/undefined.js
+++ b/src/components/editor/undefined.js
@@ -26,7 +26,7 @@ class UndefinedEditor extends StandardEditor {
    * @returns {Number} The number of characters.
    */
   size() {
-    return 9;
+    return VALUE.length;
   }
 
   /**

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -1,13 +1,12 @@
 /**
  * Get the size for the string value.
+ * Returns 1 with an empty string.
  *
  * @param {Object} value - The value.
  *
  * @return {Number} The size.
  */
-const size = (value) => {
+export const fieldStringLen = (value) => {
   const length = String(value).length;
   return length === 0 ? 1 : length;
 };
-
-export default size;


### PR DESCRIPTION
COMPASS-4423

This PR adds multi-line string input editing. It updates the html element used for string editing from input to textarea so it can be resized and more easily used for multi line and longer strings.

This also fixes a bug where a long string would overflow the field name and type changer dropdown (example of previous behavior which no longer happens):
<img width="754" alt="Screen Shot 2020-11-09 at 12 39 51 PM" src="https://user-images.githubusercontent.com/1791149/98540908-ece40900-228e-11eb-9b13-b86786ec9a1c.png">

Since this does have some styling updates it would be nice for whoever reviews the pr to give it a manual test and make sure it looks ok.

Also fixes https://github.com/mongodb-js/compass/issues/1874 

## Motivation and Context
- [x] New feature
- [x] Bug fix

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Patch (non-breaking change which fixes an issue)
- [x] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)

___
*Editing a multi string value (high res in slack since github is 10mb max)*
![multi-line string input low res](https://user-images.githubusercontent.com/1791149/98540923-f0779000-228e-11eb-8799-8e1bc8a6e3f6.gif)

