### PR TITLE
fix: field number styling

### DIFF
--- a/src/components/editable-element.less
+++ b/src/components/editable-element.less
@@ -4,7 +4,6 @@
   flex-direction: row;
   flex-wrap: nowrap;
   align-items: center;
-  position: relative;
 
   &-field {
     display: inline-block;


### PR DESCRIPTION
Broke this with recent string changes and long string formatting fix.
This PR fixes.

Currently (broken line number styling):
<img width="164" alt="Screen Shot 2020-11-12 at 12 12 16 PM" src="https://user-images.githubusercontent.com/1791149/98933908-93bfe380-24e1-11eb-9ffd-1dff27bbadaf.png">

With this PR (fixed line number styling):
<img width="180" alt="Screen Shot 2020-11-12 at 12 12 10 PM" src="https://user-images.githubusercontent.com/1791149/98933914-96223d80-24e1-11eb-8ee6-710d63f373d5.png">

*Long strings and multi-lines*
<img width="841" alt="Screen Shot 2020-11-12 at 12 21 01 PM" src="https://user-images.githubusercontent.com/1791149/98933900-90c4f300-24e1-11eb-9fbf-3dd9553503e7.png">
