### PR TITLE
chore: fix CI badge in readme

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -37,7 +37,7 @@ jobs:
             ${{ runner.os }}-
       
       - name: Install Required OS Packages
-        run: sudo apt-get -y install libkrb5-dev libsecret-1-dev
+        run: sudo apt-get -y install libkrb5-dev libsecret-1-dev net-tools
       
       - name: Install NPM Packages
         run: npm install
@@ -46,4 +46,16 @@ jobs:
         run: |
           npm run check
           npm run test
+          while true; do \
+            MATCH="$(sudo netstat -tlnp | grep 27018 || true)"; \
+            if [[ "$MATCH" == "" ]]; then echo "mongod exited..."; break; fi; \
+            echo "$MATCH"; \
+            echo "mongod still up..."; \
+            PID="$(echo $MATCH | awk '{print $7}' | cut -f1 -d'/')"; \
+            if [[ "$PID" == "" ]]; then echo "failed to find PID"; break; fi; \
+            echo "sudo killing -9 $PID..."; \
+            sudo kill -9 $PID; \
+            echo "... killed?!"; \
+            sleep 3; \
+          done
           npm run test:karma

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Compass CRUD Plugin [![][travis_img]][travis_url] [![][npm_img]][npm_url]
+# Compass CRUD Plugin [![][workflow_img]][workflow_url] [![][npm_img]][npm_url]
 
 Provide functionality shown in the "Documents" tab in the Collection view in
 Compass. 
@@ -176,8 +176,8 @@ npm install -S @mongodb-js/compass-crud
 # License
 [Apache 2.0](./LICENSE)
 
-[travis_img]: https://travis-ci.org/mongodb-js/compass-crud.svg
-[travis_url]: https://travis-ci.org/mongodb-js/compass-crud
+[workflow_img]: https://github.com/mongodb-js/compass-crud/workflows/Run%20Tests/badge.svg
+[workflow_url]: https://github.com/mongodb-js/compass-crud/actions?query=workflow%3A%22Run+Tests%22+branch%3Amaster
 [npm_img]: https://img.shields.io/npm/v/@mongodb-js/compass-crud.svg?style=flat-square
 [npm_url]: https://www.npmjs.org/package/@mongodb-js/compass-crud
 [hadron-app]: https://github.com/mongodb-js/hadron-app


### PR DESCRIPTION
## Description
Just adds the badge to the GitHub action replacing the Travis CI one.