### PR TITLE
fix(editing): stop showing document editor after refresh COMPASS-4454

### DIFF
--- a/src/components/document-footer.jsx
+++ b/src/components/document-footer.jsx
@@ -76,6 +76,17 @@ class DocumentFooter extends React.Component {
   }
 
   /**
+   * Handle a possible switch of the document that we're targeting.
+   */
+  componentDidUpdate(prevProps) {
+    if (this.props.doc !== prevProps.doc) {
+      // If the underlying document changed, that means that the collection
+      // contents have been refreshed. Treat that like cancelling the edit.
+      this.handleCancel();
+    }
+  }
+
+  /**
    * Unsubscribe from the udpate store on unmount.
    */
   componentWillUnmount() {

--- a/src/components/editable-document.jsx
+++ b/src/components/editable-document.jsx
@@ -74,6 +74,13 @@ class EditableDocument extends React.Component {
     if (prevProps.doc !== this.props.doc) {
       this.unsubscribeFromDocumentEvents(prevProps.doc);
       this.subscribeToDocumentEvents(this.props.doc);
+      if (this.state.editing || this.state.deleting) {
+        // If the underlying document changed, that means that the collection
+        // contents have been refreshed. In that case, stop editing/deleting.
+        setImmediate(() => {
+          this.setState({ editing: false, deleting: false });
+        });
+      }
     }
   }
 

--- a/src/components/editable-json.jsx
+++ b/src/components/editable-json.jsx
@@ -103,7 +103,7 @@ class JsonEditor extends React.Component {
    * Fold all documents on update as well, since we might get fresh documents
    * from the query bar.
    */
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     if (!this.state.editing) {
       this.editor.getSession().foldAll(2);
     }
@@ -113,6 +113,10 @@ class JsonEditor extends React.Component {
       this.handleRemoveSuccess();
     } else if (this.state.editing && this.props.updateSuccess) {
       this.handleUpdateSuccess();
+    } else if (this.props.doc !== prevProps.doc) {
+      // If the underlying document changed, that means that the collection
+      // contents have been refreshed. Treat that like cancelling the edit.
+      this.handleCancel();
     }
   }
 
@@ -122,6 +126,7 @@ class JsonEditor extends React.Component {
   handleCancel() {
     this.setState({
       editing: false,
+      deleting: false,
       mode: VIEWING,
       message: EMPTY,
       value: this.props.doc

--- a/src/components/json-editor.jsx
+++ b/src/components/json-editor.jsx
@@ -103,7 +103,7 @@ class EditableJson extends React.Component {
    * Fold all documents on update as well, since we might get fresh documents
    * from the query bar.
    */
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     if (!this.state.editing) {
       this.editor.getSession().foldAll(2);
     }
@@ -113,6 +113,10 @@ class EditableJson extends React.Component {
       this.handleRemoveSuccess();
     } else if (this.state.editing && this.props.updateSuccess) {
       this.handleUpdateSuccess();
+    } else if (this.props.doc !== prevProps.doc) {
+      // If the underlying document changed, that means that the collection
+      // contents have been refreshed. Treat that like cancelling the edit.
+      this.handleCancel();
     }
   }
 
@@ -122,6 +126,7 @@ class EditableJson extends React.Component {
   handleCancel() {
     this.setState({
       editing: false,
+      deleting: false,
       mode: VIEWING,
       message: EMPTY,
       json: jsBeautify(EJSON.stringify(this.props.doc.generateObject()))


### PR DESCRIPTION
Handle a hit of the `Refresh` button like cancelling the document
editing process.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
