### PR TITLE
fix: always start out with _id in ‘insert document’ view COMPASS-4511

### DIFF
--- a/src/components/insert-document-dialog.jsx
+++ b/src/components/insert-document-dialog.jsx
@@ -143,7 +143,7 @@ class InsertDocumentDialog extends React.PureComponent {
    * @returns {Boolean} If the document has errors.
    */
   hasErrors() {
-    if (this.props.jsonView && this.props.jsonDoc !== '') {
+    if (this.props.jsonView) {
       return !!jsonParse(this.props.jsonDoc).err;
     }
     return this.invalidElements.length > 0;

--- a/src/stores/crud-store.js
+++ b/src/stores/crud-store.js
@@ -585,7 +585,7 @@ const configureStore = (options = {}) => {
         }
       }
 
-      const jsonDoc = clone ? EJSON.stringify(hadronDoc.generateObject()) : '';
+      const jsonDoc = EJSON.stringify(hadronDoc.generateObject());
 
       this.setState({
         insert: {


### PR DESCRIPTION
This is the solution suggested in the ticket, preventing errors that
stem from inserting an empty document.

<!-- Ticket number and a general summary of your changes in the Title above -->
<!-- e.g. COMPASS-1111: updates ace editor width in agg pipeline view -->

<!--- The following fields are not obligatory. Use your best judgement on what you think is applicable to the work you've done -->

## Description
<!--- Describe your changes in detail -->
<!--- If applicable, describe (or illustrate) architecture flow -->
### Checklist
- [ ] New tests and/or benchmarks are included
- [ ] Documentation is changed or added

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it's updating a dependancy, link to the Pull Request that originally introduced the fix -->
- [x] Bugfix
- [ ] New feature
- [ ] Dependency update
- [ ] Misc

## Open Questions
<!--- Any particular areas you'd like reviewers to pay attention to? -->

## Dependents
<!--- If applicable, link PRs/commits that this PR is dependent on or is a dependency of. -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] *Backport Needed*
- [x] Patch (non-breaking change which fixes an issue)
- [ ] Minor (non-breaking change which adds functionality)
- [ ] Major (fix or feature that would cause existing functionality to change)
