### PR TITLE
fix: Show updated value for updated fields in table view COMPASS-4509

### DIFF
--- a/src/components/table-view/cell-editor.jsx
+++ b/src/components/table-view/cell-editor.jsx
@@ -228,9 +228,9 @@ class CellEditor extends React.Component {
       /* Update the grid store so we know what type this element is */
       this.props.elementAdded(this.element.currentKey, this.element.currentType, id);
       /* TODO: should we update column.* as well to be safe?
-       Not needed if everywhere we access columns through .getColDef() but
-       if somewhere internally they don't do that, will have outdated values.
-       Docs: https://www.ag-grid.com/javascript-grid-column-definitions
+        Not needed if everywhere we access columns through .getColDef() but
+        if somewhere internally they don't do that, will have outdated values.
+        Docs: https://www.ag-grid.com/javascript-grid-column-definitions
        */
     }
     this.props.api.refreshCells({rowNodes: [this.props.node], force: true});
@@ -258,6 +258,7 @@ class CellEditor extends React.Component {
         }
       }
     }
+    this.forceUpdate();
   }
 
   handleRemoveField() {

--- a/src/components/table-view/cell-renderer.jsx
+++ b/src/components/table-view/cell-renderer.jsx
@@ -3,7 +3,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import getComponent from 'hadron-react-bson';
 import { Element } from 'hadron-document';
-import initEditors from 'components/editor';
 
 /**
  * The BEM base style name for the cell.
@@ -87,8 +86,6 @@ class CellRenderer extends React.Component {
         }
       }
     }
-
-    this._editors = initEditors(this.element, this.props.tz);
   }
 
   componentDidMount() {
@@ -104,23 +101,26 @@ class CellRenderer extends React.Component {
   }
 
   subscribeElementEvents() {
-    this.unsubscribeReverted = this.handleReverted.bind(this);
-    this.unsubscribeEdited = this.handleEdited.bind(this);
+    this.unsubscribeAdded = this.handleElementEvent.bind(this);
+    this.unsubscribeConverted = this.handleElementEvent.bind(this);
+    this.unsubscribeEdited = this.handleElementEvent.bind(this);
+    this.unsubscribeReverted = this.handleElementEvent.bind(this);
 
-    this.element.on(Element.Events.Reverted, this.unsubscribeReverted);
+    this.element.on(Element.Events.Added, this.unsubscribeAdded);
+    this.element.on(Element.Events.Converted, this.unsubscribeConverted);
     this.element.on(Element.Events.Edited, this.unsubscribeEdited);
+    this.element.on(Element.Events.Reverted, this.unsubscribeReverted);
   }
 
   unsubscribeElementEvents() {
-    this.element.removeListener(Element.Events.Reverted, this.unsubscribeReverted);
+    this.element.removeListener(Element.Events.Added, this.unsubscribeAdded);
+    this.element.removeListener(Element.Events.Converted, this.unsubscribeConverted);
     this.element.removeListener(Element.Events.Edited, this.unsubscribeEdited);
+    this.element.removeListener(Element.Events.Reverted, this.unsubscribeReverted);
   }
 
-  handleReverted() {
+  handleElementEvent() {
     this.forceUpdate();
-  }
-
-  handleEdited() {
   }
 
   handleUndo(event) {


### PR DESCRIPTION
This PR updates it so that existing fields that are edited have their changes reflects when they are unselected. We render our table with [AG-Grid](https://www.ag-grid.com/documentation/javascript/) and have a different component for cell rendering and cell editing. We weren't reflecting the changes in the cell renderer when they happened in the cell editor. Typically ag grid should handle the cell renderer refresh, however I think because of our use of the [hadron document](https://github.com/mongodb-js/hadron-document) to store the state of the documents, ag grid doesn't quite know things have changed (maybe there's a shallow comparison somewhere?).
To fix it we now perform a forced react update when change events emit from hadron document (which the cell editor kicks off). Previously this is how we handled reverted documents. This is a bit hacky and coupled, and I think we could probably do it better, but it would take some time and I'm not sure we want to invest in that right now.

Also fixed a bug around the changed type not showing up in the cell editor. This was particularly rough when changing type to or from array/objects.

Note: I don't think this has worked in the past (maybe this pr should be a `feat`?).

Also this does not fix the updated status of undefined fields since that could potentially involve some bigger changes - open to ideas how we could make that work without doing larger rewrites here. The reason those aren't reflected is that the hadron document is created on the editor which is fully separate from the renderer and when its updated the renderer isn't notified. Interestingly when the cell is scrolled out of view and then back into view it's re-rendered with the newly updated value because the new hadron document is passed to the componentWillMount function. I'll file a ticket for that: COMPASS-4670 

Editing a field _before_:

https://user-images.githubusercontent.com/1791149/108864247-4da31180-75f2-11eb-952d-cef3be8bae02.mp4


Editing a field _after_:

https://user-images.githubusercontent.com/1791149/108864281-55fb4c80-75f2-11eb-8454-2374174ac404.mp4


Updating field type _before_:

https://user-images.githubusercontent.com/1791149/108864268-51cf2f00-75f2-11eb-9e5b-a6b1ee1a3c2e.mp4


Updating field type _after_:

https://user-images.githubusercontent.com/1791149/108864309-5c89c400-75f2-11eb-98ab-bb105b6c005d.mp4

