### PR TITLE
fix(sort): Do not modify sort before comitting it to the state COMPASS-4258

### DIFF
--- a/src/stores/crud-store.js
+++ b/src/stores/crud-store.js
@@ -1,7 +1,7 @@
 import Reflux from 'reflux';
 import toNS from 'mongodb-ns';
 import EJSON from 'mongodb-extended-json';
-import { toPairs, findIndex, isEmpty } from 'lodash';
+import { findIndex, isEmpty } from 'lodash';
 import StateMixin from 'reflux-state-mixin';
 import HadronDocument from 'hadron-document';
 import util from 'util';
@@ -221,7 +221,7 @@ const configureStore = (options = {}) => {
     getInitialQueryState() {
       return {
         filter: {},
-        sort: [],
+        sort: null,
         limit: 0,
         skip: 0,
         maxTimeMS: DEFAULT_INITIAL_MAX_TIME_MS,
@@ -281,7 +281,7 @@ const configureStore = (options = {}) => {
      */
     onQueryChanged(state) {
       this.state.query.filter = state.filter || {};
-      this.state.query.sort = toPairs(state.sort);
+      this.state.query.sort = state.sort;
       this.state.query.limit = state.limit;
       this.state.query.skip = state.skip || 0;
       this.state.query.project = state.project;

--- a/test/renderer/crud-store.spec.js
+++ b/test/renderer/crud-store.spec.js
@@ -47,7 +47,7 @@ describe('store', function() {
     });
 
     it('sets the default sort', () => {
-      expect(store.state.query.sort).to.deep.equal([]);
+      expect(store.state.query.sort).to.deep.equal(null);
     });
 
     it('sets the default limit', () => {


### PR DESCRIPTION
We want to allow array values in query sort field and for that to work, compass-crud should not apply "to pairs" processing to array values. For the objects this `toPairs` call also seems excessive (v8 keeps insert order for most objects, for objects like `{2: -1, 1: -1}` it doesn't work, and driver will convert this value to array before passing to server anyway), so instead of increasing complexity and adding `isArray` check I think the best here would be to just remove any state modification for query change action altogether