### PR TITLE
fix: Check if dataService is connected before trying to refresh docs COMPASS-4741

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12194,12 +12194,6 @@
         "lodash.restparam": "^3.0.0"
       }
     },
-    "lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha1-ZuXOH3btJ7QwPYxlEujRIW6BBrw=",
-      "dev": true
-    },
     "lodash.clone": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-3.0.3.tgz",
@@ -13637,35 +13631,10 @@
       "dev": true
     },
     "mongodb-build-info": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
-      "integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
+      "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g==",
       "dev": true
-    },
-    "mongodb-collection-sample": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/mongodb-collection-sample/-/mongodb-collection-sample-4.5.1.tgz",
-      "integrity": "sha512-tUCdRLToheOh2Tn+KVdhYtbLifxCo60+wVMf0zxtbZLKPYbZqQaYmyrYTsEunePNJyxIutBWdayX79VJ/Fb2hg==",
-      "dev": true,
-      "requires": {
-        "bson": "^4.0.3",
-        "debug": "^4.1.1",
-        "event-stream": "^4.0.1",
-        "lodash.chunk": "^4.2.0",
-        "lodash.defaults": "^4.2.0",
-        "mongodb-ns": "^2.2.0",
-        "reservoir": "^0.1.2",
-        "semver": "^5.7.1",
-        "yargs": "^15.1.0"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
-      }
     },
     "mongodb-connection-model": {
       "version": "16.1.6",
@@ -13727,18 +13696,15 @@
       }
     },
     "mongodb-data-service": {
-      "version": "16.9.3",
-      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-16.9.3.tgz",
-      "integrity": "sha512-onJp+3SOF/oQHqumxwfEKkHN1O13GbP5BUwM5uOrnT3QRetkeT3FG3tQPyX8UCJNom8+BPBn5FP9XIepl5pDtw==",
+      "version": "19.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-data-service/-/mongodb-data-service-19.2.0.tgz",
+      "integrity": "sha512-BUnNPHmSO1DQytG1DeKm6MM0Ia3ySAFckA8NaYR2MRWnCaf/Smg4Ldw72HCOS8NGWK7JZzqAmP+kOJco0B8XLQ==",
       "dev": true,
       "requires": {
         "async": "^3.2.0",
-        "debug": "^4.1.1",
-        "lodash": "^4.17.15",
-        "mongodb": "^3.6.1",
-        "mongodb-build-info": "^1.1.0",
-        "mongodb-collection-sample": "^4.5.1",
-        "mongodb-connection-model": "^16.1.6",
+        "debug": "^4.2.0",
+        "lodash": "^4.17.20",
+        "mongodb-build-info": "^1.1.1",
         "mongodb-index-model": "^2.6.1",
         "mongodb-js-errors": "^0.5.0",
         "mongodb-ns": "^2.2.0",
@@ -13752,25 +13718,20 @@
           "integrity": "sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==",
           "dev": true
         },
-        "bson": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
-          "dev": true
-        },
-        "mongodb": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.1.tgz",
-          "integrity": "sha512-uH76Zzr5wPptnjEKJRQnwTsomtFOU/kQEU8a9hKHr2M7y9qVk7Q4Pkv0EQVp88742z9+RwvsdTw6dRjDZCNu1g==",
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
-            "bl": "^2.2.0",
-            "bson": "^1.1.4",
-            "denque": "^1.4.1",
-            "require_optional": "^1.0.1",
-            "safe-buffer": "^5.1.2",
-            "saslprep": "^1.0.0"
+            "ms": "2.1.2"
           }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
         }
       }
     },
@@ -14023,9 +13984,9 @@
           "dev": true
         },
         "bson": {
-          "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.5.tgz",
-          "integrity": "sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==",
+          "version": "1.1.6",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.6.tgz",
+          "integrity": "sha512-EvVNVeGo4tHxwi8L6bPj3y3itEvStdwvvlojVxxbyYfoaxJ6keLgrTuKdyfEAszFK+H3olzBuafE0yoh0D1gdg==",
           "dev": true
         },
         "lodash.assign": {
@@ -14171,12 +14132,12 @@
           }
         },
         "mongodb": {
-          "version": "3.6.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.1.tgz",
-          "integrity": "sha512-uH76Zzr5wPptnjEKJRQnwTsomtFOU/kQEU8a9hKHr2M7y9qVk7Q4Pkv0EQVp88742z9+RwvsdTw6dRjDZCNu1g==",
+          "version": "3.6.5",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.6.5.tgz",
+          "integrity": "sha512-mQlYKw1iGbvJJejcPuyTaytq0xxlYbIoVDm2FODR+OHxyEiMR021vc32bTvamgBjCswsD54XIRwhg3yBaWqJjg==",
           "dev": true,
           "requires": {
-            "bl": "^2.2.0",
+            "bl": "^2.2.1",
             "bson": "^1.1.4",
             "denque": "^1.4.1",
             "require_optional": "^1.0.1",
@@ -17413,12 +17374,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
       "integrity": "sha1-kl0mAdOaxIXgkc8NpcbmlNw9yv8=",
-      "dev": true
-    },
-    "reservoir": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/reservoir/-/reservoir-0.1.2.tgz",
-      "integrity": "sha1-8I6sFWSVEjA5y8XuBvP1iXnkVgU=",
       "dev": true
     },
     "resolve": {

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "mongodb-ace-mode": "^0.4.0",
     "mongodb-ace-theme-query": "0.0.2",
     "mongodb-connection-model": "^16.1.6",
-    "mongodb-data-service": "^16.9.3",
+    "mongodb-data-service": "^19.2.0",
     "mongodb-ns": "^2.0.0",
     "mongodb-query-parser": "^2.2.0",
     "mongodb-runner": "^4.8.0",

--- a/src/stores/crud-store.js
+++ b/src/stores/crud-store.js
@@ -878,6 +878,14 @@ const configureStore = (options = {}) => {
      * @param {Object} filter - The query filter.
      */
     async refreshDocuments() {
+      if (this.dataService && !this.dataService.isConnected()) {
+        debug(
+          'warning: trying to refresh documents but dataService is disconnected',
+          this.dataService
+        );
+        return;
+      }
+
       if (this.isRefreshingDocuments) {
         return;
       }


### PR DESCRIPTION
This is an intermediate workaround for a leaky compass plugins issue. We don't expect `dataService` to be disconnected when these actions are dispatched ever, so technically throwing in this case might've been a right thing to do, but currently as a workaround for leaking listeners of `refresh-data` event, we just warn and no-op if `dataService` is disconnected